### PR TITLE
GitHubDesktop.munki: remove minimum_os_version from Input

### DIFF
--- a/GitHub/GitHubDesktop.munki.recipe
+++ b/GitHub/GitHubDesktop.munki.recipe
@@ -26,8 +26,6 @@
             <string>GitHub Desktop</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>minimum_os_version</key>
-            <string>10.9</string>
             <key>unattended_install</key>
             <true/>
             <key>postinstall_script</key>


### PR DESCRIPTION
- not needed as MunkiImporter (invoking makepkginfo) will automatically set the appropriate
  `minimum_os_version` key based on the app's Info.plist