### PR TITLE
Updated parent recipe name.

### DIFF
--- a/SizeUp/SizeUp.install.recipe
+++ b/SizeUp/SizeUp.install.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.poundbangbash.eholtam-recipes.irradiatedsoftware.sizeup.download</string>
+	<string>com.github.poundbangbash.eholtam-recipes.irradiatedsoftware.download.sizeup</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
I had changed my recipe name to follow standard naming schemes and to eliminate the Finder's confusion with .download and .pkg folders showing as Safari download files and .pkg containers.  Moving the .download and .pkg names now shows the cache folders as folders.