### PR TITLE
CURL back to URL

### DIFF
--- a/25io/Mou.download.recipe
+++ b/25io/Mou.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://25.io/mou/up/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/25io/Mou.download.recipe
+++ b/25io/Mou.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/25io/Smaller.download.recipe
+++ b/25io/Smaller.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/25io/Smaller.download.recipe
+++ b/25io/Smaller.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://25.io/smaller/up/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ADPassMon/ADPassMon.download.recipe
+++ b/ADPassMon/ADPassMon.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ADPassMon/ADPassMon.download.recipe
+++ b/ADPassMon/ADPassMon.download.recipe
@@ -16,7 +16,7 @@
 		<string>ADPassMon</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AirDroid/AirDroid.download.recipe
+++ b/AirDroid/AirDroid.download.recipe
@@ -16,7 +16,7 @@
 		<string>AirDroid</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AirDroid/AirDroid.download.recipe
+++ b/AirDroid/AirDroid.download.recipe
@@ -16,7 +16,7 @@
 		<string>AirDroid</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AirDroid/AirDroid.download.recipe
+++ b/AirDroid/AirDroid.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Anvil/Anvil.download.recipe
+++ b/Anvil/Anvil.download.recipe
@@ -14,7 +14,7 @@
 		<string>https://sparkler.herokuapp.com/apps/3/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Anvil/Anvil.download.recipe
+++ b/Anvil/Anvil.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Apache/ApacheDirectoryStudio.download.recipe
+++ b/Apache/ApacheDirectoryStudio.download.recipe
@@ -14,7 +14,7 @@
 		<string>ApacheDirectoryStudio</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Apache/ApacheDirectoryStudio.download.recipe
+++ b/Apache/ApacheDirectoryStudio.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://dist.apache.org/repos/dist/release/directory/studio/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Apache/ApacheDirectoryStudio.download.recipe
+++ b/Apache/ApacheDirectoryStudio.download.recipe
@@ -37,7 +37,7 @@
 				<string>https://dist.apache.org/repos/dist/release/directory/studio/%version%/ApacheDirectoryStudio-%version%-macosx.cocoa.x86_64.tar.gz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AppReviews/AppReviews.download.recipe
+++ b/AppReviews/AppReviews.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://knutigro.github.io/apps/app-reviews/app-reviews-appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AppReviews/AppReviews.download.recipe
+++ b/AppReviews/AppReviews.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AppWrapper/AppWrapper3.download.recipe
+++ b/AppWrapper/AppWrapper3.download.recipe
@@ -16,7 +16,7 @@
 		<string>App Wrapper 3</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AppWrapper/AppWrapper3.download.recipe
+++ b/AppWrapper/AppWrapper3.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AppZapper/AppZapper.download.recipe
+++ b/AppZapper/AppZapper.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AppZapper/AppZapper.download.recipe
+++ b/AppZapper/AppZapper.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.appzapper.com/az2appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AuroraHDR/Aurora HDR Pro.download.recipe
+++ b/AuroraHDR/Aurora HDR Pro.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AuroraHDR/Aurora HDR Pro.download.recipe
+++ b/AuroraHDR/Aurora HDR Pro.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://cdn.macphun.com/updates/AuroraHDRPro/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AutoCasperNBI/AutoCasperNBI.download.recipe
+++ b/AutoCasperNBI/AutoCasperNBI.download.recipe
@@ -31,7 +31,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AutoCasperNBI/AutoCasperNBI.download.recipe
+++ b/AutoCasperNBI/AutoCasperNBI.download.recipe
@@ -12,7 +12,7 @@
 		<string>AutoCasperNBI</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AutoPkgr/AutoPkgr.download.recipe
+++ b/AutoPkgr/AutoPkgr.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/AutoPkgr/AutoPkgr.download.recipe
+++ b/AutoPkgr/AutoPkgr.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://raw.githubusercontent.com/lindegroup/autopkgr/appcast/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/AutoPkgr/AutoPkgr.download.recipe
+++ b/AutoPkgr/AutoPkgr.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://raw.githubusercontent.com/lindegroup/autopkgr/appcast/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Automattic/WordPress.com.download.recipe
+++ b/Automattic/WordPress.com.download.recipe
@@ -39,7 +39,7 @@
 				<string>https://public-api.wordpress.com/%download_path%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Automattic/WordPress.com.download.recipe
+++ b/Automattic/WordPress.com.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://developer.wordpress.com/calypso/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Automattic/WordPress.com.download.recipe
+++ b/Automattic/WordPress.com.download.recipe
@@ -14,7 +14,7 @@
 		<string>WordPress.com</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Automattic/WordPress.com.download.recipe
+++ b/Automattic/WordPress.com.download.recipe
@@ -14,7 +14,7 @@
 		<string>WordPress.com</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Avira/AviraFreeMacSecurity.download.recipe
+++ b/Avira/AviraFreeMacSecurity.download.recipe
@@ -24,7 +24,7 @@
 				<string>AviraFreeMacSecurity.pkg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Avira/AviraFreeMacSecurity.download.recipe
+++ b/Avira/AviraFreeMacSecurity.download.recipe
@@ -12,7 +12,7 @@
 		<string>Avira Free Mac Security</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BetterTouchTool/BetterTouchTool.download.recipe
+++ b/BetterTouchTool/BetterTouchTool.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BetterTouchTool/BetterTouchTool.download.recipe
+++ b/BetterTouchTool/BetterTouchTool.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://appcast.boastr.net</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BetterUnarchiver/BetterUnarchiver.download.recipe
+++ b/BetterUnarchiver/BetterUnarchiver.download.recipe
@@ -16,7 +16,7 @@
 		<string>Cisdem BetterUnarchiver</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BetterUnarchiver/BetterUnarchiver.download.recipe
+++ b/BetterUnarchiver/BetterUnarchiver.download.recipe
@@ -16,7 +16,7 @@
 		<string>Cisdem BetterUnarchiver</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BetterUnarchiver/BetterUnarchiver.download.recipe
+++ b/BetterUnarchiver/BetterUnarchiver.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BetterWindowManager/BetterWindowManager.download.recipe
+++ b/BetterWindowManager/BetterWindowManager.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BetterWindowManager/BetterWindowManager.download.recipe
+++ b/BetterWindowManager/BetterWindowManager.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.gngrwzrd.com/betterwindowmanager-appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BitTorrentSync/BitTorrentSync.download.recipe
+++ b/BitTorrentSync/BitTorrentSync.download.recipe
@@ -16,7 +16,7 @@
 		<string>BitTorrent Sync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BitTorrentSync/BitTorrentSync.download.recipe
+++ b/BitTorrentSync/BitTorrentSync.download.recipe
@@ -16,7 +16,7 @@
 		<string>BitTorrent Sync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BitTorrentSync/BitTorrentSync.download.recipe
+++ b/BitTorrentSync/BitTorrentSync.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Bjango/SkalaColorInstaller.download.recipe
+++ b/Bjango/SkalaColorInstaller.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Bjango/SkalaColorInstaller.download.recipe
+++ b/Bjango/SkalaColorInstaller.download.recipe
@@ -14,7 +14,7 @@
 		<string>SkalaColor</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Bjango/SkalaPreview.download.recipe
+++ b/Bjango/SkalaPreview.download.recipe
@@ -16,7 +16,7 @@
 		<string>Skala Preview</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Bjango/SkalaPreview.download.recipe
+++ b/Bjango/SkalaPreview.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BlackPixel/ForkLift.download.recipe
+++ b/BlackPixel/ForkLift.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://update.binarynights.com/ForkLift2/update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BlackPixel/ForkLift.download.recipe
+++ b/BlackPixel/ForkLift.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BlackPixel/NetNewsWire.download.recipe
+++ b/BlackPixel/NetNewsWire.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BlackPixel/NetNewsWire.download.recipe
+++ b/BlackPixel/NetNewsWire.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.blackpixel.com/updates?app=nnw</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BohemianCoding/Sketch.download.recipe
+++ b/BohemianCoding/Sketch.download.recipe
@@ -16,7 +16,7 @@
 		<string>Sketch</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BohemianCoding/Sketch.download.recipe
+++ b/BohemianCoding/Sketch.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Bookends/Bookends.download.recipe
+++ b/Bookends/Bookends.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Boom/Boom2.download.recipe
+++ b/Boom/Boom2.download.recipe
@@ -16,7 +16,7 @@
 		<string>Boom 2</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Boom/Boom2.download.recipe
+++ b/Boom/Boom2.download.recipe
@@ -16,7 +16,7 @@
 		<string>Boom 2</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Boom/Boom2.download.recipe
+++ b/Boom/Boom2.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/BootstrapStudio/BootstrapStudio.download.recipe
+++ b/BootstrapStudio/BootstrapStudio.download.recipe
@@ -16,7 +16,7 @@
 		<string>Bootstrap Studio</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/BootstrapStudio/BootstrapStudio.download.recipe
+++ b/BootstrapStudio/BootstrapStudio.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/C-Command/DropDMG.download.recipe
+++ b/C-Command/DropDMG.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://c-command.com/dropdmg/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/C-Command/DropDMG.download.recipe
+++ b/C-Command/DropDMG.download.recipe
@@ -14,7 +14,7 @@
 		<string>DropDMG</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/C-Command/DropDMG.download.recipe
+++ b/C-Command/DropDMG.download.recipe
@@ -39,7 +39,7 @@
 				<string>http://c-command.com/downloads/DropDMG-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/C-Command/DropDMG.download.recipe
+++ b/C-Command/DropDMG.download.recipe
@@ -14,7 +14,7 @@
 		<string>DropDMG</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/C-Command/EagleFiler.download.recipe
+++ b/C-Command/EagleFiler.download.recipe
@@ -14,7 +14,7 @@
 		<string>EagleFiler</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/C-Command/EagleFiler.download.recipe
+++ b/C-Command/EagleFiler.download.recipe
@@ -39,7 +39,7 @@
 				<string>http://c-command.com/downloads/EagleFiler-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/C-Command/EagleFiler.download.recipe
+++ b/C-Command/EagleFiler.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://c-command.com/eaglefiler/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/C-Command/EagleFiler.download.recipe
+++ b/C-Command/EagleFiler.download.recipe
@@ -14,7 +14,7 @@
 		<string>EagleFiler</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/C-Command/SpamSieve.download.recipe
+++ b/C-Command/SpamSieve.download.recipe
@@ -39,7 +39,7 @@
 				<string>http://c-command.com/downloads/SpamSieve-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/C-Command/SpamSieve.download.recipe
+++ b/C-Command/SpamSieve.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://c-command.com/spamsieve/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/C-Command/SpamSieve.download.recipe
+++ b/C-Command/SpamSieve.download.recipe
@@ -14,7 +14,7 @@
 		<string>SpamSieve</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/C-Command/SpamSieve.download.recipe
+++ b/C-Command/SpamSieve.download.recipe
@@ -14,7 +14,7 @@
 		<string>SpamSieve</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CCleaner/CCleaner.download.recipe
+++ b/CCleaner/CCleaner.download.recipe
@@ -14,7 +14,7 @@
 		<string>CCleaner</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CCleaner/CCleaner.download.recipe
+++ b/CCleaner/CCleaner.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://www.piriform.com/ccleaner/download?mac</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/CCleaner/CCleaner.download.recipe
+++ b/CCleaner/CCleaner.download.recipe
@@ -39,7 +39,7 @@
 				<string>https://download.piriform.com/%url%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CCleaner/CCleaner.download.recipe
+++ b/CCleaner/CCleaner.download.recipe
@@ -14,7 +14,7 @@
 		<string>CCleaner</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CakeBrew/CakeBrew.download.recipe
+++ b/CakeBrew/CakeBrew.download.recipe
@@ -37,7 +37,7 @@ WARNING: The identifier of this recipe will soon change to com.github.homebysix.
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CakeBrew/CakeBrew.download.recipe
+++ b/CakeBrew/CakeBrew.download.recipe
@@ -18,7 +18,7 @@ WARNING: The identifier of this recipe will soon change to com.github.homebysix.
 		<string>https://www.cakebrew.com/appcast/profileInfo.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CaseApps/SofaControl.download.recipe
+++ b/CaseApps/SofaControl.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.caseapps.com/downloads/sofacontrol-update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CaseApps/SofaControl.download.recipe
+++ b/CaseApps/SofaControl.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CaseApps/SofaControl.download.recipe
+++ b/CaseApps/SofaControl.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.caseapps.com/downloads/sofacontrol-update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CaseApps/Tags.download.recipe
+++ b/CaseApps/Tags.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CaseApps/Tags.download.recipe
+++ b/CaseApps/Tags.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.caseapps.com/downloads/updates/tags/tags2-update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CaseApps/Tags.download.recipe
+++ b/CaseApps/Tags.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.caseapps.com/downloads/updates/tags/tags2-update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Celestia/Celestia.download.recipe
+++ b/Celestia/Celestia.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Celestia/Celestia.download.recipe
+++ b/Celestia/Celestia.download.recipe
@@ -14,7 +14,7 @@
 		<string>Celestia</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Celestia/Celestia.download.recipe
+++ b/Celestia/Celestia.download.recipe
@@ -14,7 +14,7 @@
 		<string>Celestia</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CharlesSoft/CocoaTADS.download.recipe
+++ b/CharlesSoft/CocoaTADS.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CharlesSoft/NibUnlocker.download.recipe
+++ b/CharlesSoft/NibUnlocker.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CharlesSoft/TimeTracker.download.recipe
+++ b/CharlesSoft/TimeTracker.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Chat/Chat.download.recipe
+++ b/Chat/Chat.download.recipe
@@ -16,7 +16,7 @@
 		<string>Chat</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Chat/Chat.download.recipe
+++ b/Chat/Chat.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ChronoSync/ChronoAgent.download.recipe
+++ b/ChronoSync/ChronoAgent.download.recipe
@@ -14,7 +14,7 @@
 		<string>ChronoAgent</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ChronoSync/ChronoAgent.download.recipe
+++ b/ChronoSync/ChronoAgent.download.recipe
@@ -14,7 +14,7 @@
 		<string>ChronoAgent</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ChronoSync/ChronoAgent.download.recipe
+++ b/ChronoSync/ChronoAgent.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ChronoSync/ChronoSync.download.recipe
+++ b/ChronoSync/ChronoSync.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ChronoSync/ChronoSync.download.recipe
+++ b/ChronoSync/ChronoSync.download.recipe
@@ -14,7 +14,7 @@
 		<string>ChronoSync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ChronoSync/ChronoSync.download.recipe
+++ b/ChronoSync/ChronoSync.download.recipe
@@ -14,7 +14,7 @@
 		<string>ChronoSync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cisco/Proximity.download.recipe
+++ b/Cisco/Proximity.download.recipe
@@ -16,7 +16,7 @@
 		<string>Proximity</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cisco/Proximity.download.recipe
+++ b/Cisco/Proximity.download.recipe
@@ -16,7 +16,7 @@
 		<string>Proximity</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cisco/Proximity.download.recipe
+++ b/Cisco/Proximity.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Clarify/Clarify.download.recipe
+++ b/Clarify/Clarify.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Clarify/Clarify.download.recipe
+++ b/Clarify/Clarify.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.bluemangolearning.com/download/clarify/2_0/auto_update/release/clarify_appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cockos/licecap.download.recipe
+++ b/Cockos/licecap.download.recipe
@@ -39,7 +39,7 @@
 				<string>http://www.cockos.com/licecap/licecap%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Cockos/licecap.download.recipe
+++ b/Cockos/licecap.download.recipe
@@ -30,7 +30,7 @@
 				<string>http://www.cockos.com/licecap/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Cockos/licecap.download.recipe
+++ b/Cockos/licecap.download.recipe
@@ -16,7 +16,7 @@
 		<string>licecap</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cockos/licecap.download.recipe
+++ b/Cockos/licecap.download.recipe
@@ -16,7 +16,7 @@
 		<string>licecap</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cocktail/Cocktail-10.10.download.recipe
+++ b/Cocktail/Cocktail-10.10.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Cocktail/Cocktail-10.11.download.recipe
+++ b/Cocktail/Cocktail-10.11.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Cocktail/Cocktail-10.11.download.recipe
+++ b/Cocktail/Cocktail-10.11.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Cocktail/Cocktail-10.6.download.recipe
+++ b/Cocktail/Cocktail-10.6.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Cocktail/Cocktail-10.7.download.recipe
+++ b/Cocktail/Cocktail-10.7.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Cocktail/Cocktail-10.8.download.recipe
+++ b/Cocktail/Cocktail-10.8.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Cocktail/Cocktail-10.9.download.recipe
+++ b/Cocktail/Cocktail-10.9.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CocoaPods/CocoaPods.download.recipe
+++ b/CocoaPods/CocoaPods.download.recipe
@@ -16,7 +16,7 @@
 		<string>CocoaPods</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CocoaPods/CocoaPods.download.recipe
+++ b/CocoaPods/CocoaPods.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tar.bz2</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CocoaRestClient/CocoaRestClient.download.recipe
+++ b/CocoaRestClient/CocoaRestClient.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/CocoaRestClient/CocoaRestClient.download.recipe
+++ b/CocoaRestClient/CocoaRestClient.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://restlesscode.org/cocoa-rest-client/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CocoaRestClient/CocoaRestClient.download.recipe
+++ b/CocoaRestClient/CocoaRestClient.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://restlesscode.org/cocoa-rest-client/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ColorSnapper/ColorSnapper.download.recipe
+++ b/ColorSnapper/ColorSnapper.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://colorsnapper.com/app/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ColorSnapper/ColorSnapper.download.recipe
+++ b/ColorSnapper/ColorSnapper.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Compose/Compose.download.recipe
+++ b/Compose/Compose.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://xn--getcompos-j4a.com/updates-feed/</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Compose/Compose.download.recipe
+++ b/Compose/Compose.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Contexts/Contexts.download.recipe
+++ b/Contexts/Contexts.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Contexts/Contexts.download.recipe
+++ b/Contexts/Contexts.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://contexts.co/appcasts/stable.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CopyClip/CopyClip.download.recipe
+++ b/CopyClip/CopyClip.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://rink.hockeyapp.net/api/2/apps/082cf4b1e3613fad8de3075a6ac2903a</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CopyClip/CopyClip.download.recipe
+++ b/CopyClip/CopyClip.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DeliciousMonster/DeliciousLibrary.download.recipe
+++ b/DeliciousMonster/DeliciousLibrary.download.recipe
@@ -16,7 +16,7 @@
 		<string>Delicious Library 3</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DeliciousMonster/DeliciousLibrary.download.recipe
+++ b/DeliciousMonster/DeliciousLibrary.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Deltopia/DeltaWalker.download.recipe
+++ b/Deltopia/DeltaWalker.download.recipe
@@ -16,7 +16,7 @@
 		<string>DeltaWalker</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Deltopia/DeltaWalker.download.recipe
+++ b/Deltopia/DeltaWalker.download.recipe
@@ -16,7 +16,7 @@
 		<string>DeltaWalker</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Deltopia/DeltaWalker.download.recipe
+++ b/Deltopia/DeltaWalker.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DevonTechnologies/DEVONagentExpress.download.recipe
+++ b/DevonTechnologies/DEVONagentExpress.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.devon-technologies.com/Sparkle/DEVONagentExpress.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DevonTechnologies/DEVONagentExpress.download.recipe
+++ b/DevonTechnologies/DEVONagentExpress.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DevonTechnologies/DEVONagentPro.download.recipe
+++ b/DevonTechnologies/DEVONagentPro.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DevonTechnologies/DEVONagentPro.download.recipe
+++ b/DevonTechnologies/DEVONagentPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.devon-technologies.com/Sparkle/DEVONagent.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DevonTechnologies/DEVONsphereExpress.download.recipe
+++ b/DevonTechnologies/DEVONsphereExpress.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.devon-technologies.com/Sparkle/DEVONsphereExpress.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DevonTechnologies/DEVONsphereExpress.download.recipe
+++ b/DevonTechnologies/DEVONsphereExpress.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DevonTechnologies/DEVONthinkPersonal.download.recipe
+++ b/DevonTechnologies/DEVONthinkPersonal.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.devon-technologies.com/Sparkle/DEVONthink2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DevonTechnologies/DEVONthinkPersonal.download.recipe
+++ b/DevonTechnologies/DEVONthinkPersonal.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DevonTechnologies/DEVONthinkPro.download.recipe
+++ b/DevonTechnologies/DEVONthinkPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.devon-technologies.com/Sparkle/DEVONthinkPro2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DevonTechnologies/DEVONthinkPro.download.recipe
+++ b/DevonTechnologies/DEVONthinkPro.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DevonTechnologies/DEVONthinkProOffice.download.recipe
+++ b/DevonTechnologies/DEVONthinkProOffice.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.devon-technologies.com/Sparkle/DEVONthinkProOffice2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DevonTechnologies/DEVONthinkProOffice.download.recipe
+++ b/DevonTechnologies/DEVONthinkProOffice.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Docker/DockerToolbox.download.recipe
+++ b/Docker/DockerToolbox.download.recipe
@@ -28,7 +28,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Docker/DockerToolbox.download.recipe
+++ b/Docker/DockerToolbox.download.recipe
@@ -12,7 +12,7 @@
 		<string>DockerToolbox</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Dropbox/Mailbox.download.recipe
+++ b/Dropbox/Mailbox.download.recipe
@@ -40,7 +40,7 @@ NOTE: Mailbox is no longer under active development, so this recipe may not exis
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Dropbox/Mailbox.download.recipe
+++ b/Dropbox/Mailbox.download.recipe
@@ -21,7 +21,7 @@ NOTE: Mailbox is no longer under active development, so this recipe may not exis
 		<string>https://rink.hockeyapp.net/api/2/apps/0de2e5766e01cde1f6c0fd5b9862c730</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DuetDisplay/duet.download.recipe
+++ b/DuetDisplay/duet.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/DuetDisplay/duet.download.recipe
+++ b/DuetDisplay/duet.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.duetdisplay.com/checkMacUpdates</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/EVE/EVE.download.recipe
+++ b/EVE/EVE.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://s3.amazonaws.com/hotkeyeve/hotkeyEVEappcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/EVE/EVE.download.recipe
+++ b/EVE/EVE.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Egnyte/EgnyteDesktopSync.download.recipe
+++ b/Egnyte/EgnyteDesktopSync.download.recipe
@@ -14,7 +14,7 @@
 		<string>Egnyte Desktop Sync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Egnyte/EgnyteDesktopSync.download.recipe
+++ b/Egnyte/EgnyteDesktopSync.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://helpdesk.egnyte.com/hc/en-us/articles/201636844</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -41,7 +41,7 @@
 				<string>https://helpdesk.egnyte.com/hc/en-us/articles/201636844</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Egnyte/EgnyteDesktopSync.download.recipe
+++ b/Egnyte/EgnyteDesktopSync.download.recipe
@@ -14,7 +14,7 @@
 		<string>Egnyte Desktop Sync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Egnyte/EgnyteDesktopSync.download.recipe
+++ b/Egnyte/EgnyteDesktopSync.download.recipe
@@ -52,7 +52,7 @@
 				<string>%download_url%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/EmailArchiverPro/EmailArchiverPro2.download.recipe
+++ b/EmailArchiverPro/EmailArchiverPro2.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/EmailArchiverPro/EmailArchiverPro3.download.recipe
+++ b/EmailArchiverPro/EmailArchiverPro3.download.recipe
@@ -31,7 +31,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Emailchemy/Emailchemy.download.recipe
+++ b/Emailchemy/Emailchemy.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Emailchemy/Emailchemy.download.recipe
+++ b/Emailchemy/Emailchemy.download.recipe
@@ -14,7 +14,7 @@
 		<string>Emailchemy</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Emailchemy/Emailchemy.download.recipe
+++ b/Emailchemy/Emailchemy.download.recipe
@@ -14,7 +14,7 @@
 		<string>Emailchemy</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Endurance/Endurance.download.recipe
+++ b/Endurance/Endurance.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://enduranceapp.com/appcast</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Endurance/Endurance.download.recipe
+++ b/Endurance/Endurance.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Epoch/Epoch.download.recipe
+++ b/Epoch/Epoch.download.recipe
@@ -14,7 +14,7 @@
 		<string>Epoch</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Epoch/Epoch.download.recipe
+++ b/Epoch/Epoch.download.recipe
@@ -14,7 +14,7 @@
 		<string>Epoch</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Epoch/Epoch.download.recipe
+++ b/Epoch/Epoch.download.recipe
@@ -37,7 +37,7 @@
 				<string>https://s3.amazonaws.com/%urlpath%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Epoch/Epoch.download.recipe
+++ b/Epoch/Epoch.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://dashboard.adcade.com/downloads</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/FatCatSoftware/PlistEditPro.download.recipe
+++ b/FatCatSoftware/PlistEditPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>PlistEdit Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FatCatSoftware/PlistEditPro.download.recipe
+++ b/FatCatSoftware/PlistEditPro.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FatCatSoftware/PowerPhotos.download.recipe
+++ b/FatCatSoftware/PowerPhotos.download.recipe
@@ -16,7 +16,7 @@
 		<string>PowerPhotos</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FatCatSoftware/PowerPhotos.download.recipe
+++ b/FatCatSoftware/PowerPhotos.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FatCatSoftware/PowerTunes.download.recipe
+++ b/FatCatSoftware/PowerTunes.download.recipe
@@ -16,7 +16,7 @@
 		<string>PowerTunes</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FatCatSoftware/PowerTunes.download.recipe
+++ b/FatCatSoftware/PowerTunes.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FatCatSoftware/iPhotoLibraryManager.download.recipe
+++ b/FatCatSoftware/iPhotoLibraryManager.download.recipe
@@ -16,7 +16,7 @@
 		<string>iPhoto Library Manager</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FatCatSoftware/iPhotoLibraryManager.download.recipe
+++ b/FatCatSoftware/iPhotoLibraryManager.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FindAnyFile/FindAnyFile.download.recipe
+++ b/FindAnyFile/FindAnyFile.download.recipe
@@ -16,7 +16,7 @@
 		<string>Find Any File</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FindAnyFile/FindAnyFile.download.recipe
+++ b/FindAnyFile/FindAnyFile.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Flashlight/Flashlight.download.recipe
+++ b/Flashlight/Flashlight.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Flashlight/Flashlight.download.recipe
+++ b/Flashlight/Flashlight.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://raw.githubusercontent.com/nate-parrott/flashlight/master/Appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Flinto/Flinto.download.recipe
+++ b/Flinto/Flinto.download.recipe
@@ -16,7 +16,7 @@
 		<string>Flinto</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Flinto/Flinto.download.recipe
+++ b/Flinto/Flinto.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FlyingMeat/Acorn.download.recipe
+++ b/FlyingMeat/Acorn.download.recipe
@@ -16,7 +16,7 @@
 		<string>Acorn</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FlyingMeat/Acorn.download.recipe
+++ b/FlyingMeat/Acorn.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Focus/Focus.download.recipe
+++ b/Focus/Focus.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://heyfocus.com/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Focus/Focus.download.recipe
+++ b/Focus/Focus.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FoldingText/FoldingText.download.recipe
+++ b/FoldingText/FoldingText.download.recipe
@@ -16,7 +16,7 @@
 		<string>FoldingText</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FoldingText/FoldingText.download.recipe
+++ b/FoldingText/FoldingText.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FoldingText/FoldingText.download.recipe
+++ b/FoldingText/FoldingText.download.recipe
@@ -16,7 +16,7 @@
 		<string>FoldingText</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Folio/Folio.download.recipe
+++ b/Folio/Folio.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://s3.amazonaws.com/folioformac.com/folioupdates.xml.rss</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Folio/Folio.download.recipe
+++ b/Folio/Folio.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FontFinagler/FontFinagler.download.recipe
+++ b/FontFinagler/FontFinagler.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.markdouma.com/fontfinagler/version.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FontFinagler/FontFinagler.download.recipe
+++ b/FontFinagler/FontFinagler.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FontNuke/FontNuke.download.recipe
+++ b/FontNuke/FontNuke.download.recipe
@@ -37,7 +37,7 @@ This set of recipes differs from the one in wardsparadox-recipes because it prov
 				<string>%NAME%-%version%.tgz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/FontNuke/FontNuke.download.recipe
+++ b/FontNuke/FontNuke.download.recipe
@@ -18,7 +18,7 @@ This set of recipes differs from the one in wardsparadox-recipes because it prov
 		<string>http://jamapi.com/fontnuke/fontnuke-update-appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GasMask/GasMask.download.recipe
+++ b/GasMask/GasMask.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/GasMask/GasMask.download.recipe
+++ b/GasMask/GasMask.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://gmask.clockwise.ee/check_update/</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GitHub/GitHubDesktop.download.recipe
+++ b/GitHub/GitHubDesktop.download.recipe
@@ -16,7 +16,7 @@
 		<string>GitHub Desktop</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GitHub/GitHubDesktop.download.recipe
+++ b/GitHub/GitHubDesktop.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Gitify/Gitify.download.recipe
+++ b/Gitify/Gitify.download.recipe
@@ -16,7 +16,7 @@
 		<string>Gitify</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Gitify/Gitify.download.recipe
+++ b/Gitify/Gitify.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/GoToMeeting/GoToMeeting.download.recipe
+++ b/GoToMeeting/GoToMeeting.download.recipe
@@ -28,7 +28,7 @@
 				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Goofy/Goofy.download.recipe
+++ b/Goofy/Goofy.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://raw.githubusercontent.com/danielbuechele/goofy/master/update_feed.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Goofy/Goofy.download.recipe
+++ b/Goofy/Goofy.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Grammarly/Grammarly.download.recipe
+++ b/Grammarly/Grammarly.download.recipe
@@ -16,7 +16,7 @@
 		<string>Grammarly</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Grammarly/Grammarly.download.recipe
+++ b/Grammarly/Grammarly.download.recipe
@@ -16,7 +16,7 @@
 		<string>Grammarly</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Grammarly/Grammarly.download.recipe
+++ b/Grammarly/Grammarly.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/GrandPerspective/GrandPerspective.download.recipe
+++ b/GrandPerspective/GrandPerspective.download.recipe
@@ -14,7 +14,7 @@
 		<string>GrandPerspective</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GrandPerspective/GrandPerspective.download.recipe
+++ b/GrandPerspective/GrandPerspective.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/GrandPerspective/GrandPerspective.download.recipe
+++ b/GrandPerspective/GrandPerspective.download.recipe
@@ -14,7 +14,7 @@
 		<string>GrandPerspective</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Helium/Helium.download.recipe
+++ b/Helium/Helium.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Helium/Helium.download.recipe
+++ b/Helium/Helium.download.recipe
@@ -14,7 +14,7 @@
 		<string>Helium</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/HocusFocus/HocusFocus.download.recipe
+++ b/HocusFocus/HocusFocus.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/HocusFocus/HocusFocus.download.recipe
+++ b/HocusFocus/HocusFocus.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://hocusfoc.us/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Houdah/HoudahGeo.download.recipe
+++ b/Houdah/HoudahGeo.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.houdah.com/houdahGeo/updates4/cast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Houdah/HoudahGeo.download.recipe
+++ b/Houdah/HoudahGeo.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Houdah/HoudahSpot.download.recipe
+++ b/Houdah/HoudahSpot.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Houdah/HoudahSpot.download.recipe
+++ b/Houdah/HoudahSpot.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.houdah.com/houdahSpot/updates/cast4.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Houdah/Tembo.download.recipe
+++ b/Houdah/Tembo.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Houdah/Tembo.download.recipe
+++ b/Houdah/Tembo.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.houdah.com/tembo/updates/cast2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/IconGrabber/IconGrabber.download.recipe
+++ b/IconGrabber/IconGrabber.download.recipe
@@ -16,7 +16,7 @@
 		<string>Icon Grabber</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/IconGrabber/IconGrabber.download.recipe
+++ b/IconGrabber/IconGrabber.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/IconGrabber/IconGrabber.download.recipe
+++ b/IconGrabber/IconGrabber.download.recipe
@@ -16,7 +16,7 @@
 		<string>Icon Grabber</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Iconfactory/Twitterrific.download.recipe
+++ b/Iconfactory/Twitterrific.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://iconfactory.com/appcasts/Twitterrific/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Iconfactory/Twitterrific.download.recipe
+++ b/Iconfactory/Twitterrific.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Iconfactory/xScope.download.recipe
+++ b/Iconfactory/xScope.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Iconfactory/xScope.download.recipe
+++ b/Iconfactory/xScope.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://iconfactory.com/appcasts/xScope/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InboxApp/NylasN1.download.recipe
+++ b/InboxApp/NylasN1.download.recipe
@@ -16,7 +16,7 @@
 		<string>Nylas N1</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InboxApp/NylasN1.download.recipe
+++ b/InboxApp/NylasN1.download.recipe
@@ -16,7 +16,7 @@
 		<string>Nylas N1</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InboxApp/NylasN1.download.recipe
+++ b/InboxApp/NylasN1.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Infinit/Infinit.download.recipe
+++ b/Infinit/Infinit.download.recipe
@@ -16,7 +16,7 @@
 		<string>Infinit</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Infinit/Infinit.download.recipe
+++ b/Infinit/Infinit.download.recipe
@@ -16,7 +16,7 @@
 		<string>Infinit</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Infinit/Infinit.download.recipe
+++ b/Infinit/Infinit.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Inky/Inky.download.recipe
+++ b/Inky/Inky.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Inky/Inky.download.recipe
+++ b/Inky/Inky.download.recipe
@@ -16,7 +16,7 @@
 		<string>Inky</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Inky/Inky.download.recipe
+++ b/Inky/Inky.download.recipe
@@ -16,7 +16,7 @@
 		<string>Inky</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InsiliCo/CodeCookbookforSwift.download.recipe
+++ b/InsiliCo/CodeCookbookforSwift.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://iswift.org/codecookbook.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InsiliCo/CodeCookbookforSwift.download.recipe
+++ b/InsiliCo/CodeCookbookforSwift.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/InsiliCo/iSwift.download.recipe
+++ b/InsiliCo/iSwift.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://iswift.org/iswift.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/InsiliCo/iSwift.download.recipe
+++ b/InsiliCo/iSwift.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/IrradiatedSoftware/SwitchUp.download.recipe
+++ b/IrradiatedSoftware/SwitchUp.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.irradiatedsoftware.com/updates/profiles/switchup.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/IrradiatedSoftware/SwitchUp.download.recipe
+++ b/IrradiatedSoftware/SwitchUp.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/IrradiatedSoftware/Tickets.download.recipe
+++ b/IrradiatedSoftware/Tickets.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.irradiatedsoftware.com/updates/profiles/tickets.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/IrradiatedSoftware/Tickets.download.recipe
+++ b/IrradiatedSoftware/Tickets.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/IrradiatedSoftware/Tuck.download.recipe
+++ b/IrradiatedSoftware/Tuck.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/IrradiatedSoftware/Tuck.download.recipe
+++ b/IrradiatedSoftware/Tuck.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.irradiatedsoftware.com/updates/profiles/tuck.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/IrradiatedSoftware/iClip.download.recipe
+++ b/IrradiatedSoftware/iClip.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.irradiatedsoftware.com/updates/profiles/iclip.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/IrradiatedSoftware/iClip.download.recipe
+++ b/IrradiatedSoftware/iClip.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/JSSImporter/JSSImporter.download.recipe
+++ b/JSSImporter/JSSImporter.download.recipe
@@ -31,7 +31,7 @@
 				<string>%NAME%.pkg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/JSSImporter/JSSImporter.download.recipe
+++ b/JSSImporter/JSSImporter.download.recipe
@@ -12,7 +12,7 @@
 		<string>JSSImporter</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Karelia/Sandvox.download.recipe
+++ b/Karelia/Sandvox.download.recipe
@@ -16,7 +16,7 @@
 		<string>Sandvox</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Karelia/Sandvox.download.recipe
+++ b/Karelia/Sandvox.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Karelia/Tangerine.download.recipe
+++ b/Karelia/Tangerine.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://launch.karelia.com/appcast.php?version=0&amp;product=13&amp;appname=Tangerine</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Karelia/Tangerine.download.recipe
+++ b/Karelia/Tangerine.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Karelia/TheHitList.download.recipe
+++ b/Karelia/TheHitList.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://launch.karelia.com/appcast.php?product=9&amp;appname=The+Hit+List</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Karelia/TheHitList.download.recipe
+++ b/Karelia/TheHitList.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -39,7 +39,7 @@
 				<string>https://www.keepassx.org/releases/%version%/KeePassX-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -14,7 +14,7 @@
 		<string>KeePassX</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://www.keepassx.org/downloads/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -14,7 +14,7 @@
 		<string>KeePassX</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/KerbMinder/KerbMinder.download.recipe
+++ b/KerbMinder/KerbMinder.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/KerbMinder/KerbMinder.download.recipe
+++ b/KerbMinder/KerbMinder.download.recipe
@@ -16,7 +16,7 @@
 		<string>KerbMinder</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AirRadar.download.recipe
+++ b/Koingo/AirRadar.download.recipe
@@ -16,7 +16,7 @@
 		<string>AirRadar</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AirRadar.download.recipe
+++ b/Koingo/AirRadar.download.recipe
@@ -16,7 +16,7 @@
 		<string>AirRadar</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AirRadar.download.recipe
+++ b/Koingo/AirRadar.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/AlarmClockPro.download.recipe
+++ b/Koingo/AlarmClockPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Alarm Clock Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AlarmClockPro.download.recipe
+++ b/Koingo/AlarmClockPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Alarm Clock Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AlarmClockPro.download.recipe
+++ b/Koingo/AlarmClockPro.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/AppBolish.download.recipe
+++ b/Koingo/AppBolish.download.recipe
@@ -16,7 +16,7 @@
 		<string>AppBolish</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AppBolish.download.recipe
+++ b/Koingo/AppBolish.download.recipe
@@ -16,7 +16,7 @@
 		<string>AppBolish</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/AppBolish.download.recipe
+++ b/Koingo/AppBolish.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/DataGuardian.download.recipe
+++ b/Koingo/DataGuardian.download.recipe
@@ -16,7 +16,7 @@
 		<string>Data Guardian</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/DataGuardian.download.recipe
+++ b/Koingo/DataGuardian.download.recipe
@@ -16,7 +16,7 @@
 		<string>Data Guardian</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/DataGuardian.download.recipe
+++ b/Koingo/DataGuardian.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/DigitalSentry.download.recipe
+++ b/Koingo/DigitalSentry.download.recipe
@@ -16,7 +16,7 @@
 		<string>Digital Sentry</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/DigitalSentry.download.recipe
+++ b/Koingo/DigitalSentry.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/DigitalSentry.download.recipe
+++ b/Koingo/DigitalSentry.download.recipe
@@ -16,7 +16,7 @@
 		<string>Digital Sentry</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/DisplayMaestro.download.recipe
+++ b/Koingo/DisplayMaestro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Display Maestro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/DisplayMaestro.download.recipe
+++ b/Koingo/DisplayMaestro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Display Maestro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/DisplayMaestro.download.recipe
+++ b/Koingo/DisplayMaestro.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/LibrarianPro.download.recipe
+++ b/Koingo/LibrarianPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Librarian Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/LibrarianPro.download.recipe
+++ b/Koingo/LibrarianPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Librarian Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/LibrarianPro.download.recipe
+++ b/Koingo/LibrarianPro.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/MacPilot.download.recipe
+++ b/Koingo/MacPilot.download.recipe
@@ -16,7 +16,7 @@
 		<string>MacPilot</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/MacPilot.download.recipe
+++ b/Koingo/MacPilot.download.recipe
@@ -16,7 +16,7 @@
 		<string>MacPilot</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/MacPilot.download.recipe
+++ b/Koingo/MacPilot.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/ProjectCanvas.download.recipe
+++ b/Koingo/ProjectCanvas.download.recipe
@@ -16,7 +16,7 @@
 		<string>Project Canvas</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/ProjectCanvas.download.recipe
+++ b/Koingo/ProjectCanvas.download.recipe
@@ -16,7 +16,7 @@
 		<string>Project Canvas</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/ProjectCanvas.download.recipe
+++ b/Koingo/ProjectCanvas.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Koingo/RoboPostman.download.recipe
+++ b/Koingo/RoboPostman.download.recipe
@@ -16,7 +16,7 @@
 		<string>RoboPostman</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/RoboPostman.download.recipe
+++ b/Koingo/RoboPostman.download.recipe
@@ -16,7 +16,7 @@
 		<string>RoboPostman</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Koingo/RoboPostman.download.recipe
+++ b/Koingo/RoboPostman.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Laplock/laplock.download.recipe
+++ b/Laplock/laplock.download.recipe
@@ -16,7 +16,7 @@
 		<string>laplock</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Laplock/laplock.download.recipe
+++ b/Laplock/laplock.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/LemkeSoft/GraphicConverter9.download.recipe
+++ b/LemkeSoft/GraphicConverter9.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/LemkeSoft/GraphicConverter9.download.recipe
+++ b/LemkeSoft/GraphicConverter9.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.lemkesoft.org/files/graphicconverter/graphicconverter9.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/LiteratureAndLatte/Scapple.download.recipe
+++ b/LiteratureAndLatte/Scapple.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.literatureandlatte.com/downloads/scapple/scapple.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/LiteratureAndLatte/Scapple.download.recipe
+++ b/LiteratureAndLatte/Scapple.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/LiteratureAndLatte/Scrivener.download.recipe
+++ b/LiteratureAndLatte/Scrivener.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/LiteratureAndLatte/Scrivener.download.recipe
+++ b/LiteratureAndLatte/Scrivener.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.literatureandlatte.com/downloads/scrivener-2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/LiveSurfaceContext/LiveSurfaceContext.download.recipe
+++ b/LiveSurfaceContext/LiveSurfaceContext.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://context.livesurface.com/94775618/updates.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/LiveSurfaceContext/LiveSurfaceContext.download.recipe
+++ b/LiveSurfaceContext/LiveSurfaceContext.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacDVDRipperPro/MacDVDRipperPro.download.recipe
+++ b/MacDVDRipperPro/MacDVDRipperPro.download.recipe
@@ -41,7 +41,7 @@ This set of recipes differs from the ones provided by macvfx-recipes in the foll
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacDVDRipperPro/MacDVDRipperPro.download.recipe
+++ b/MacDVDRipperPro/MacDVDRipperPro.download.recipe
@@ -22,7 +22,7 @@ This set of recipes differs from the ones provided by macvfx-recipes in the foll
 		<string>https://www.macdvdripperpro.com/mdrp_sparkle5.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacPaw/CleanMyMac2.download.recipe
+++ b/MacPaw/CleanMyMac2.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://updateinfo.devmate.com/com.macpaw.CleanMyMac2/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacPaw/CleanMyMac2.download.recipe
+++ b/MacPaw/CleanMyMac2.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacPaw/CleanMyMac3-beta.download.recipe
+++ b/MacPaw/CleanMyMac3-beta.download.recipe
@@ -16,7 +16,7 @@
 		<string>CleanMyMac 3</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacPaw/CleanMyMac3-beta.download.recipe
+++ b/MacPaw/CleanMyMac3-beta.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacPaw/CleanMyMac3.download.recipe
+++ b/MacPaw/CleanMyMac3.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://updateinfo.devmate.com/com.macpaw.CleanMyMac3/updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacPaw/CleanMyMac3.download.recipe
+++ b/MacPaw/CleanMyMac3.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacPaw/Gemini.download.recipe
+++ b/MacPaw/Gemini.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacPaw/Gemini.download.recipe
+++ b/MacPaw/Gemini.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.devmate.com/com.macpaw.site.Gemini.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacPaw/Hider2.download.recipe
+++ b/MacPaw/Hider2.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.devmate.com/com.macpaw.site.Hider2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacPaw/Hider2.download.recipe
+++ b/MacPaw/Hider2.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacRabbit/Espresso.download.recipe
+++ b/MacRabbit/Espresso.download.recipe
@@ -16,7 +16,7 @@
 		<string>Espresso</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacRabbit/Espresso.download.recipe
+++ b/MacRabbit/Espresso.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacRabbit/Slicy.download.recipe
+++ b/MacRabbit/Slicy.download.recipe
@@ -16,7 +16,7 @@
 		<string>Slicy</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacRabbit/Slicy.download.recipe
+++ b/MacRabbit/Slicy.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MacTerm/MacTerm.download.recipe
+++ b/MacTerm/MacTerm.download.recipe
@@ -16,7 +16,7 @@
 		<string>MacTerm</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacTerm/MacTerm.download.recipe
+++ b/MacTerm/MacTerm.download.recipe
@@ -16,7 +16,7 @@
 		<string>MacTerm</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MacTerm/MacTerm.download.recipe
+++ b/MacTerm/MacTerm.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Macroplant/Adapter.download.recipe
+++ b/Macroplant/Adapter.download.recipe
@@ -16,7 +16,7 @@
 		<string>Adapter</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Macroplant/Adapter.download.recipe
+++ b/Macroplant/Adapter.download.recipe
@@ -16,7 +16,7 @@
 		<string>Adapter</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Macroplant/Adapter.download.recipe
+++ b/Macroplant/Adapter.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Butler.download.recipe
+++ b/ManyTricks/Butler.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Butler.download.recipe
+++ b/ManyTricks/Butler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/butler/butlercast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Butler.download.recipe
+++ b/ManyTricks/Butler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/butler/butlercast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/DesktopCurtain.download.recipe
+++ b/ManyTricks/DesktopCurtain.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/DesktopCurtain.download.recipe
+++ b/ManyTricks/DesktopCurtain.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/desktopcurtain/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/DesktopCurtain.download.recipe
+++ b/ManyTricks/DesktopCurtain.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/desktopcurtain/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Displaperture.download.recipe
+++ b/ManyTricks/Displaperture.download.recipe
@@ -16,7 +16,7 @@
 		<string>Displaperture</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Displaperture.download.recipe
+++ b/ManyTricks/Displaperture.download.recipe
@@ -16,7 +16,7 @@
 		<string>Displaperture</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Displaperture.download.recipe
+++ b/ManyTricks/Displaperture.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/KeyCodes.download.recipe
+++ b/ManyTricks/KeyCodes.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/KeyCodes.download.recipe
+++ b/ManyTricks/KeyCodes.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/keycodes/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/KeyCodes.download.recipe
+++ b/ManyTricks/KeyCodes.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/keycodes/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Keymo.download.recipe
+++ b/ManyTricks/Keymo.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/keymo/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Keymo.download.recipe
+++ b/ManyTricks/Keymo.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Keymo.download.recipe
+++ b/ManyTricks/Keymo.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/keymo/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Leech.download.recipe
+++ b/ManyTricks/Leech.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Leech.download.recipe
+++ b/ManyTricks/Leech.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/leech/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Leech.download.recipe
+++ b/ManyTricks/Leech.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/leech/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Moom.download.recipe
+++ b/ManyTricks/Moom.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Moom.download.recipe
+++ b/ManyTricks/Moom.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/moom/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Moom.download.recipe
+++ b/ManyTricks/Moom.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/moom/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/NameMangler.download.recipe
+++ b/ManyTricks/NameMangler.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/NameMangler.download.recipe
+++ b/ManyTricks/NameMangler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/namemangler/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/NameMangler.download.recipe
+++ b/ManyTricks/NameMangler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/namemangler/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/OpenWithManager.download.recipe
+++ b/ManyTricks/OpenWithManager.download.recipe
@@ -16,7 +16,7 @@
 		<string>Open-With Manager</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/OpenWithManager.download.recipe
+++ b/ManyTricks/OpenWithManager.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/OpenWithManager.download.recipe
+++ b/ManyTricks/OpenWithManager.download.recipe
@@ -16,7 +16,7 @@
 		<string>Open-With Manager</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Resolutionator.download.recipe
+++ b/ManyTricks/Resolutionator.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Resolutionator.download.recipe
+++ b/ManyTricks/Resolutionator.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/resolutionator/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Resolutionator.download.recipe
+++ b/ManyTricks/Resolutionator.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/resolutionator/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/TimeSink.download.recipe
+++ b/ManyTricks/TimeSink.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/TimeSink.download.recipe
+++ b/ManyTricks/TimeSink.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/timesink/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/TimeSink.download.recipe
+++ b/ManyTricks/TimeSink.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/timesink/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Usher.download.recipe
+++ b/ManyTricks/Usher.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ManyTricks/Usher.download.recipe
+++ b/ManyTricks/Usher.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/usher/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ManyTricks/Usher.download.recipe
+++ b/ManyTricks/Usher.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://manytricks.com/usher/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MarinerSoftware/MacGourmet.download.recipe
+++ b/MarinerSoftware/MacGourmet.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.marinersoftware.com/sparkle/MacGourmet4/macgourmet4.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MarinerSoftware/MacGourmet.download.recipe
+++ b/MarinerSoftware/MacGourmet.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tgz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MarinerSoftware/MacJournal.download.recipe
+++ b/MarinerSoftware/MacJournal.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MarinerSoftware/MacJournal.download.recipe
+++ b/MarinerSoftware/MacJournal.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://danschimpf.com/appcasts/MacJournal6.appcast</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MarinerSoftware/MarinerWrite.download.recipe
+++ b/MarinerSoftware/MarinerWrite.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.marinersoftware.com/sparkle/MarinerWrite/marinerwrite.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MarinerSoftware/MarinerWrite.download.recipe
+++ b/MarinerSoftware/MarinerWrite.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tgz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MarinerSoftware/Persona.download.recipe
+++ b/MarinerSoftware/Persona.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.marinersoftware.com/sparkle/persona/persona.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MarinerSoftware/Persona.download.recipe
+++ b/MarinerSoftware/Persona.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tgz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MartianCraft/Briefs.download.recipe
+++ b/MartianCraft/Briefs.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MartianCraft/Briefs.download.recipe
+++ b/MartianCraft/Briefs.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://giveabrief.s3.amazonaws.com/briefsAppCast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MartianCraft/Changes.download.recipe
+++ b/MartianCraft/Changes.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MartianCraft/Changes.download.recipe
+++ b/MartianCraft/Changes.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://bitbq_changes.s3.amazonaws.com/changes-production.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MartianCraft/Slender.download.recipe
+++ b/MartianCraft/Slender.download.recipe
@@ -16,7 +16,7 @@
 		<string>Slender</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MartianCraft/Slender.download.recipe
+++ b/MartianCraft/Slender.download.recipe
@@ -30,7 +30,7 @@
 				<string>http://martiancraft.com/products/slender.html</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MartianCraft/Slender.download.recipe
+++ b/MartianCraft/Slender.download.recipe
@@ -34,7 +34,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Mellel/Mellel.download.recipe
+++ b/Mellel/Mellel.download.recipe
@@ -14,7 +14,7 @@
 		<string>Mellel</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mellel/Mellel.download.recipe
+++ b/Mellel/Mellel.download.recipe
@@ -14,7 +14,7 @@
 		<string>Mellel</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mellel/Mellel.download.recipe
+++ b/Mellel/Mellel.download.recipe
@@ -37,7 +37,7 @@
 				<string>%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Mellel/Mellel.download.recipe
+++ b/Mellel/Mellel.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://www.mellel.com/thanks-for-downloading</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/MerlinProject/MerlinProject.download.recipe
+++ b/MerlinProject/MerlinProject.download.recipe
@@ -16,7 +16,7 @@
 		<string>Merlin Project</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MerlinProject/MerlinProject.download.recipe
+++ b/MerlinProject/MerlinProject.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Metabase/Metabase.download.recipe
+++ b/Metabase/Metabase.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Metabase/Metabase.download.recipe
+++ b/Metabase/Metabase.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://s3.amazonaws.com/downloads.metabase.com/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MockSmtp/MockSmtp.download.recipe
+++ b/MockSmtp/MockSmtp.download.recipe
@@ -16,7 +16,7 @@
 		<string>MockSmtp</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MockSmtp/MockSmtp.download.recipe
+++ b/MockSmtp/MockSmtp.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Monodraw/Monodraw.download.recipe
+++ b/Monodraw/Monodraw.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://updates.helftone.com/monodraw/appcast-beta.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Monodraw/Monodraw.download.recipe
+++ b/Monodraw/Monodraw.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Monolingual/Monolingual.download.recipe
+++ b/Monolingual/Monolingual.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tar.bz2</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Monolingual/Monolingual.download.recipe
+++ b/Monolingual/Monolingual.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://ingmarstein.github.io/Monolingual/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mountain/Mountain.download.recipe
+++ b/Mountain/Mountain.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://appgineers.de/mountain/files/mountaincast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Mountain/Mountain.download.recipe
+++ b/Mountain/Mountain.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/MyMixApps/FilePane.download.recipe
+++ b/MyMixApps/FilePane.download.recipe
@@ -16,7 +16,7 @@
 		<string>FilePane</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MyMixApps/FilePane.download.recipe
+++ b/MyMixApps/FilePane.download.recipe
@@ -16,7 +16,7 @@
 		<string>FilePane</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/MyMixApps/FilePane.download.recipe
+++ b/MyMixApps/FilePane.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/NameChanger/NameChanger.download.recipe
+++ b/NameChanger/NameChanger.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/NameChanger/NameChanger.download.recipe
+++ b/NameChanger/NameChanger.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NeoFinder/NeoFinder.download.recipe
+++ b/NeoFinder/NeoFinder.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.wfs-apps.de/updates/neofinder-appcast-64.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NeoFinder/NeoFinder.download.recipe
+++ b/NeoFinder/NeoFinder.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/NetSurf/NetSurf-testbuild.download.recipe
+++ b/NetSurf/NetSurf-testbuild.download.recipe
@@ -39,7 +39,7 @@ WARNING: The test builds of NetSurf can be unstable. Better to use the regular N
 				<string>http://ci.netsurf-browser.org/builds/cocoa/%download_filename%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/NetSurf/NetSurf-testbuild.download.recipe
+++ b/NetSurf/NetSurf-testbuild.download.recipe
@@ -16,7 +16,7 @@ WARNING: The test builds of NetSurf can be unstable. Better to use the regular N
 		<string>NetSurf</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NetSurf/NetSurf-testbuild.download.recipe
+++ b/NetSurf/NetSurf-testbuild.download.recipe
@@ -30,7 +30,7 @@ WARNING: The test builds of NetSurf can be unstable. Better to use the regular N
 				<string>http://ci.netsurf-browser.org/builds/cocoa/LATEST</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/NetSurf/NetSurf-testbuild.download.recipe
+++ b/NetSurf/NetSurf-testbuild.download.recipe
@@ -16,7 +16,7 @@ WARNING: The test builds of NetSurf can be unstable. Better to use the regular N
 		<string>NetSurf</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NetSurf/NetSurf.download.recipe
+++ b/NetSurf/NetSurf.download.recipe
@@ -14,7 +14,7 @@
 		<string>NetSurf</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NetSurf/NetSurf.download.recipe
+++ b/NetSurf/NetSurf.download.recipe
@@ -39,7 +39,7 @@
 				<string>http://download.netsurf-browser.org/netsurf/releases/pre-built/macosx/NetSurf-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/NetSurf/NetSurf.download.recipe
+++ b/NetSurf/NetSurf.download.recipe
@@ -14,7 +14,7 @@
 		<string>NetSurf</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NetSurf/NetSurf.download.recipe
+++ b/NetSurf/NetSurf.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://www.netsurf-browser.org/downloads/macosx/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/NothingMagical/Whiskey.download.recipe
+++ b/NothingMagical/Whiskey.download.recipe
@@ -16,7 +16,7 @@
 		<string>Whiskey</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/NothingMagical/Whiskey.download.recipe
+++ b/NothingMagical/Whiskey.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Numi/Numi.download.recipe
+++ b/Numi/Numi.download.recipe
@@ -16,7 +16,7 @@
 		<string>Numi</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Numi/Numi.download.recipe
+++ b/Numi/Numi.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ObjectiveDevelopment/LaunchBar.download.recipe
+++ b/ObjectiveDevelopment/LaunchBar.download.recipe
@@ -46,7 +46,7 @@
 				<string>https://www.obdev.at/downloads/launchbar/%match%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ObjectiveDevelopment/LaunchBar.download.recipe
+++ b/ObjectiveDevelopment/LaunchBar.download.recipe
@@ -21,7 +21,7 @@
 		<string>LaunchBar</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ObjectiveDevelopment/LaunchBar.download.recipe
+++ b/ObjectiveDevelopment/LaunchBar.download.recipe
@@ -35,7 +35,7 @@
 				<string>https://www.obdev.at/products/launchbar/download.html</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/ObjectiveDevelopment/LaunchBar.download.recipe
+++ b/ObjectiveDevelopment/LaunchBar.download.recipe
@@ -21,7 +21,7 @@
 		<string>LaunchBar</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PDFKit/PDFKit.download.recipe
+++ b/PDFKit/PDFKit.download.recipe
@@ -16,7 +16,7 @@
 		<string>PDFKit</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PDFKit/PDFKit.download.recipe
+++ b/PDFKit/PDFKit.download.recipe
@@ -16,7 +16,7 @@
 		<string>PDFKit</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PDFKit/PDFKit.download.recipe
+++ b/PDFKit/PDFKit.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Panic/TransmitDisk.download.recipe
+++ b/Panic/TransmitDisk.download.recipe
@@ -26,7 +26,7 @@
 				<string>https://download.panic.com/transmit/?C=M;O=D</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Panic/TransmitDisk.download.recipe
+++ b/Panic/TransmitDisk.download.recipe
@@ -35,7 +35,7 @@
 				<string>https://download.panic.com/transmit/Transmit%20Disk%20%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Panic/TransmitDisk.download.recipe
+++ b/Panic/TransmitDisk.download.recipe
@@ -12,7 +12,7 @@
 		<string>Transmit Disk</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Paparazzi/Paparazzi.download.recipe
+++ b/Paparazzi/Paparazzi.download.recipe
@@ -33,7 +33,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Papers/Papers.download.recipe
+++ b/Papers/Papers.download.recipe
@@ -39,7 +39,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Papers/Papers.download.recipe
+++ b/Papers/Papers.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://appcaster.papersapp.com/apps/mac/production/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Papers/Papers.download.recipe
+++ b/Papers/Papers.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://appcaster.papersapp.com/apps/mac/production/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -16,7 +16,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 		<string>Parallels Desktop</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -28,7 +28,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 				<string>http://www.parallels.com/directdownload/pd%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -16,7 +16,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 		<string>Parallels Desktop</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Pixate/PixateStudio.download.recipe
+++ b/Pixate/PixateStudio.download.recipe
@@ -16,7 +16,7 @@
 		<string>Pixate Studio</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Pixate/PixateStudio.download.recipe
+++ b/Pixate/PixateStudio.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ProfitTrain/ProfitTrain.download.recipe
+++ b/ProfitTrain/ProfitTrain.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://media.razorant.com/profittrain/releases/pt_appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ProfitTrain/ProfitTrain.download.recipe
+++ b/ProfitTrain/ProfitTrain.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/PublicSpace/ABetterFinderAttributes.download.recipe
+++ b/PublicSpace/ABetterFinderAttributes.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 		<string>http://www.publicspace.net/app/signed_abfa5.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PublicSpace/ABetterFinderAttributes.download.recipe
+++ b/PublicSpace/ABetterFinderAttributes.download.recipe
@@ -37,7 +37,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/PublicSpace/ABetterFinderRename.download.recipe
+++ b/PublicSpace/ABetterFinderRename.download.recipe
@@ -20,7 +20,7 @@ MAJOR_VERSION input variable can be either 9 or 10.</string>
 		<string>A Better Finder Rename</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PublicSpace/ABetterFinderRename.download.recipe
+++ b/PublicSpace/ABetterFinderRename.download.recipe
@@ -39,7 +39,7 @@ MAJOR_VERSION input variable can be either 9 or 10.</string>
 				<string>ABetterFinderRename-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/PublicSpace/BigMeanFolderMachine.download.recipe
+++ b/PublicSpace/BigMeanFolderMachine.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 		<string>http://www.publicspace.net/app/bmfm2.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PublicSpace/BigMeanFolderMachine.download.recipe
+++ b/PublicSpace/BigMeanFolderMachine.download.recipe
@@ -37,7 +37,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/PublicSpace/MacBreakZ.download.recipe
+++ b/PublicSpace/MacBreakZ.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 		<string>http://www.publicspace.net/app/signed_mb5.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/PublicSpace/MacBreakZ.download.recipe
+++ b/PublicSpace/MacBreakZ.download.recipe
@@ -37,7 +37,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/PublicSpace/NoiseMachine.download.recipe
+++ b/PublicSpace/NoiseMachine.download.recipe
@@ -37,7 +37,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/PublicSpace/NoiseMachine.download.recipe
+++ b/PublicSpace/NoiseMachine.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 		<string>http://www.publicspace.net/app/nm.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Quip/Quip.download.recipe
+++ b/Quip/Quip.download.recipe
@@ -29,7 +29,7 @@
 				<string>https://quip.com/downloads/auto</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Quip/Quip.download.recipe
+++ b/Quip/Quip.download.recipe
@@ -12,7 +12,7 @@
 		<string>Quip</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Quip/Quip.download.recipe
+++ b/Quip/Quip.download.recipe
@@ -12,7 +12,7 @@
 		<string>Quip</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/R/R.download.recipe
+++ b/R/R.download.recipe
@@ -12,7 +12,7 @@
 		<string>R</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/R/R.download.recipe
+++ b/R/R.download.recipe
@@ -48,7 +48,7 @@
 				<string>https://cran.r-project.org/bin/macosx/%filename%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/R/R.download.recipe
+++ b/R/R.download.recipe
@@ -26,7 +26,7 @@
 				<string>https://cran.r-project.org/bin/macosx/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -39,7 +39,7 @@
 				<string>https://cran.r-project.org/bin/macosx/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Radi/Radi.download.recipe
+++ b/Radi/Radi.download.recipe
@@ -16,7 +16,7 @@
 		<string>Radi</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Radi/Radi.download.recipe
+++ b/Radi/Radi.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RagingMenace/MenuMeters.download.recipe
+++ b/RagingMenace/MenuMeters.download.recipe
@@ -12,7 +12,7 @@
 		<string>MenuMeters</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RagingMenace/MenuMeters.download.recipe
+++ b/RagingMenace/MenuMeters.download.recipe
@@ -12,7 +12,7 @@
 		<string>MenuMeters</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RagingMenace/MenuMeters.download.recipe
+++ b/RagingMenace/MenuMeters.download.recipe
@@ -22,7 +22,7 @@
 				<string>http://www.ragingmenace.com/software/download/MenuMeters.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RainerBrockerhoff/RBAppCheckerLite.download.recipe
+++ b/RainerBrockerhoff/RBAppCheckerLite.download.recipe
@@ -16,7 +16,7 @@
 		<string>RB App Checker Lite</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RainerBrockerhoff/RBAppCheckerLite.download.recipe
+++ b/RainerBrockerhoff/RBAppCheckerLite.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RainerBrockerhoff/RBAppQuarantine.download.recipe
+++ b/RainerBrockerhoff/RBAppQuarantine.download.recipe
@@ -16,7 +16,7 @@
 		<string>RB App Quarantine</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RainerBrockerhoff/RBAppQuarantine.download.recipe
+++ b/RainerBrockerhoff/RBAppQuarantine.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Rdio/Rdio.download.recipe
+++ b/Rdio/Rdio.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 		<string>https://www.rdio.com/media/static/desktop/mac/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Rdio/Rdio.download.recipe
+++ b/Rdio/Rdio.download.recipe
@@ -37,7 +37,7 @@ Temporarily disabled code signature verification due to errors in included Spark
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RealMac/DeepDreamer.download.recipe
+++ b/RealMac/DeepDreamer.download.recipe
@@ -30,7 +30,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RealMac/DeepDreamer.download.recipe
+++ b/RealMac/DeepDreamer.download.recipe
@@ -18,7 +18,7 @@
 		<string>Deep Dreamer (Public Beta)</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RealMac/Ember.download.recipe
+++ b/RealMac/Ember.download.recipe
@@ -37,7 +37,7 @@
 				<string>http://downloads.realmacmedia.com/ember/%url%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RealMac/Ember.download.recipe
+++ b/RealMac/Ember.download.recipe
@@ -12,7 +12,7 @@
 		<string>Ember</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RealMac/Ember.download.recipe
+++ b/RealMac/Ember.download.recipe
@@ -26,7 +26,7 @@
 				<string>http://downloads.realmacmedia.com/ember/?C=M;O=D</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/RealMac/RapidWeaver.download.recipe
+++ b/RealMac/RapidWeaver.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Recipe Robot/Recipe Robot.download.recipe
+++ b/Recipe Robot/Recipe Robot.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Recipe Robot/Recipe Robot.download.recipe
+++ b/Recipe Robot/Recipe Robot.download.recipe
@@ -16,7 +16,7 @@
 		<string>Recipe Robot</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Recipe Robot/Recipe Robot.download.recipe
+++ b/Recipe Robot/Recipe Robot.download.recipe
@@ -16,7 +16,7 @@
 		<string>Recipe Robot</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RecordIt/RecordIt.download.recipe
+++ b/RecordIt/RecordIt.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RecordIt/RecordIt.download.recipe
+++ b/RecordIt/RecordIt.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://rink.hockeyapp.net/api/2/apps/5fcda0b48f1dcf0c938b289b9ab57790</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Reinvented/Feeder.download.recipe
+++ b/Reinvented/Feeder.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://reinventedsoftware.com/feeder/downloads/Feeder3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Reinvented/Feeder.download.recipe
+++ b/Reinvented/Feeder.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Reinvented/Feeder.download.recipe
+++ b/Reinvented/Feeder.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://reinventedsoftware.com/feeder/downloads/Feeder3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Reinvented/Together.download.recipe
+++ b/Reinvented/Together.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://reinventedsoftware.com/together/downloads/Together3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Reinvented/Together.download.recipe
+++ b/Reinvented/Together.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Reinvented/Together.download.recipe
+++ b/Reinvented/Together.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://reinventedsoftware.com/together/downloads/Together3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Renamer/Renamer.download.recipe
+++ b/Renamer/Renamer.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://creativebe.com/download/renamer</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Renamer/Renamer.download.recipe
+++ b/Renamer/Renamer.download.recipe
@@ -28,7 +28,7 @@
 				<string>%URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Revisions/Revisions.download.recipe
+++ b/Revisions/Revisions.download.recipe
@@ -35,7 +35,7 @@
 				<string>https://www.revisionsapp.com/downloads/revisions-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Revisions/Revisions.download.recipe
+++ b/Revisions/Revisions.download.recipe
@@ -12,7 +12,7 @@
 		<string>Revisions</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Revisions/Revisions.download.recipe
+++ b/Revisions/Revisions.download.recipe
@@ -12,7 +12,7 @@
 		<string>Revisions</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Revisions/Revisions.download.recipe
+++ b/Revisions/Revisions.download.recipe
@@ -26,7 +26,7 @@
 				<string>https://www.revisionsapp.com/releases</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Riffsy/GIFforMac.download.recipe
+++ b/Riffsy/GIFforMac.download.recipe
@@ -16,7 +16,7 @@
 		<string>GIF for Mac</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Riffsy/GIFforMac.download.recipe
+++ b/Riffsy/GIFforMac.download.recipe
@@ -16,7 +16,7 @@
 		<string>GIF for Mac</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Riffsy/GIFforMac.download.recipe
+++ b/Riffsy/GIFforMac.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RightFont/RightFont.download.recipe
+++ b/RightFont/RightFont.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://rightfontapp.com/update/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RightFont/RightFont.download.recipe
+++ b/RightFont/RightFont.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RogueAmoeba/AirFoil.download.recipe
+++ b/RogueAmoeba/AirFoil.download.recipe
@@ -24,7 +24,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RogueAmoeba/AudioHijack.download.recipe
+++ b/RogueAmoeba/AudioHijack.download.recipe
@@ -16,7 +16,7 @@
 		<string>Audio Hijack</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RogueAmoeba/AudioHijack.download.recipe
+++ b/RogueAmoeba/AudioHijack.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RogueAmoeba/Fission.download.recipe
+++ b/RogueAmoeba/Fission.download.recipe
@@ -16,7 +16,7 @@
 		<string>Fission</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RogueAmoeba/Fission.download.recipe
+++ b/RogueAmoeba/Fission.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RogueAmoeba/Nicecast.download.recipe
+++ b/RogueAmoeba/Nicecast.download.recipe
@@ -16,7 +16,7 @@
 		<string>Nicecast</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RogueAmoeba/Nicecast.download.recipe
+++ b/RogueAmoeba/Nicecast.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/RogueAmoeba/Piezo.download.recipe
+++ b/RogueAmoeba/Piezo.download.recipe
@@ -16,7 +16,7 @@
 		<string>Piezo</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/RogueAmoeba/Piezo.download.recipe
+++ b/RogueAmoeba/Piezo.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Royal/RoyalTSX.download.recipe
+++ b/Royal/RoyalTSX.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://www.royalapplications.com/ts/osx/download</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Royal/RoyalTSX.download.recipe
+++ b/Royal/RoyalTSX.download.recipe
@@ -14,7 +14,7 @@
 		<string>Royal TSX</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Royal/RoyalTSX.download.recipe
+++ b/Royal/RoyalTSX.download.recipe
@@ -14,7 +14,7 @@
 		<string>Royal TSX</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Royal/RoyalTSX.download.recipe
+++ b/Royal/RoyalTSX.download.recipe
@@ -32,7 +32,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Screens/Screens.download.recipe
+++ b/Screens/Screens.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Screens/Screens.download.recipe
+++ b/Screens/Screens.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.edovia.com/com.edovia.screens.mac/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SelfControl/SelfControl.download.recipe
+++ b/SelfControl/SelfControl.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://selfcontrolapp.com/SelfControlAppcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SelfControl/SelfControl.download.recipe
+++ b/SelfControl/SelfControl.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ShareMouse/ShareMouse.download.recipe
+++ b/ShareMouse/ShareMouse.download.recipe
@@ -16,7 +16,7 @@
 		<string>ShareMouse</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ShareMouse/ShareMouse.download.recipe
+++ b/ShareMouse/ShareMouse.download.recipe
@@ -16,7 +16,7 @@
 		<string>ShareMouse</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ShareMouse/ShareMouse.download.recipe
+++ b/ShareMouse/ShareMouse.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Shimo/Shimo.download.recipe
+++ b/Shimo/Shimo.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Shimo/Shimo.download.recipe
+++ b/Shimo/Shimo.download.recipe
@@ -16,7 +16,7 @@
 		<string>Shimo</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ShirtPocket/SuperDuper.download.recipe
+++ b/ShirtPocket/SuperDuper.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Simon/Simon.download.recipe
+++ b/Simon/Simon.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Simon/Simon.download.recipe
+++ b/Simon/Simon.download.recipe
@@ -16,7 +16,7 @@
 		<string>Simon</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Skim/Skim.download.recipe
+++ b/Skim/Skim.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Skim/Skim.download.recipe
+++ b/Skim/Skim.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://skim-app.sourceforge.net/skim.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Skim/Skim.download.recipe
+++ b/Skim/Skim.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://skim-app.sourceforge.net/skim.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Smultron/Smultron7.download.recipe
+++ b/Smultron/Smultron7.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.peterborgapps.com/updates/smultron7-appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Smultron/Smultron7.download.recipe
+++ b/Smultron/Smultron7.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Smultron/Smultron8.download.recipe
+++ b/Smultron/Smultron8.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Smultron/Smultron8.download.recipe
+++ b/Smultron/Smultron8.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://www.peterborgapps.com/updates/smultron8-appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SnapGene/SnapGeneViewer.download.recipe
+++ b/SnapGene/SnapGeneViewer.download.recipe
@@ -14,7 +14,7 @@
 		<string>SnapGene Viewer</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SnapGene/SnapGeneViewer.download.recipe
+++ b/SnapGene/SnapGeneViewer.download.recipe
@@ -30,7 +30,7 @@
 			<key>Comment</key>
 			<string>Scrapes the "major" version number of the current SnapGene Viewer release.</string>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -45,7 +45,7 @@
 			<key>Comment</key>
 			<string>Scrapes the full version number of the current SnapGene Viewer release.</string>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/SnapGene/SnapGeneViewer.download.recipe
+++ b/SnapGene/SnapGeneViewer.download.recipe
@@ -56,7 +56,7 @@
 				<string>http://www.snapgene.com//products/snapgene_viewer/download.php?&amp;majorRelease=%majorversion%&amp;minorRelease=%version%&amp;os=mac</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SnapGene/SnapGeneViewer.download.recipe
+++ b/SnapGene/SnapGeneViewer.download.recipe
@@ -14,7 +14,7 @@
 		<string>SnapGene Viewer</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Snippets/Snippets.download.recipe
+++ b/Snippets/Snippets.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://snippets.me/mac/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Snippets/Snippets.download.recipe
+++ b/Snippets/Snippets.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SoftPress/Exhibeo.download.recipe
+++ b/SoftPress/Exhibeo.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SoftPress/Exhibeo.download.recipe
+++ b/SoftPress/Exhibeo.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://kevin.softpress.com/sparkle/appcast.php?app=exhibeo</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SoftPress/FreewayExpress.download.recipe
+++ b/SoftPress/FreewayExpress.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SoftPress/FreewayPro.download.recipe
+++ b/SoftPress/FreewayPro.download.recipe
@@ -16,7 +16,7 @@
 		<string>Freeway Pro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SoftPress/FreewayPro.download.recipe
+++ b/SoftPress/FreewayPro.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SousChef/SousChef.download.recipe
+++ b/SousChef/SousChef.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://acaciatreesoftware.com/download/souschef.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SousChef/SousChef.download.recipe
+++ b/SousChef/SousChef.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Sparkle/Sparkle.download.recipe
+++ b/Sparkle/Sparkle.download.recipe
@@ -16,7 +16,7 @@
 		<string>Sparkle</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Sparkle/Sparkle.download.recipe
+++ b/Sparkle/Sparkle.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SpiderOak/SpiderOakONE.download.recipe
+++ b/SpiderOak/SpiderOakONE.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SpiderOak/SpiderOakONE.download.recipe
+++ b/SpiderOak/SpiderOakONE.download.recipe
@@ -14,7 +14,7 @@
 		<string>SpiderOakONE</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SpiderOak/SpiderOakONE.download.recipe
+++ b/SpiderOak/SpiderOakONE.download.recipe
@@ -14,7 +14,7 @@
 		<string>SpiderOakONE</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Stand/Stand.download.recipe
+++ b/Stand/Stand.download.recipe
@@ -33,7 +33,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Stand/Stand.download.recipe
+++ b/Stand/Stand.download.recipe
@@ -16,7 +16,7 @@
 		<string>Stand</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/StickyBrain/StickyBrain.download.recipe
+++ b/StickyBrain/StickyBrain.download.recipe
@@ -16,7 +16,7 @@
 		<string>StickyBrain</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/StickyBrain/StickyBrain.download.recipe
+++ b/StickyBrain/StickyBrain.download.recipe
@@ -16,7 +16,7 @@
 		<string>StickyBrain</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/StickyBrain/StickyBrain.download.recipe
+++ b/StickyBrain/StickyBrain.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/StretchLink/StretchLink.download.recipe
+++ b/StretchLink/StretchLink.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://abyss.designheresy.com/stretchlink/stretchlink.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/StretchLink/StretchLink.download.recipe
+++ b/StretchLink/StretchLink.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SugarSync/SugarSync.download.recipe
+++ b/SugarSync/SugarSync.download.recipe
@@ -16,7 +16,7 @@
 		<string>SugarSync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SugarSync/SugarSync.download.recipe
+++ b/SugarSync/SugarSync.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SugarSync/SugarSync.download.recipe
+++ b/SugarSync/SugarSync.download.recipe
@@ -16,7 +16,7 @@
 		<string>SugarSync</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SuperMegaUltraGroovy/Capo.download.recipe
+++ b/SuperMegaUltraGroovy/Capo.download.recipe
@@ -16,7 +16,7 @@
 		<string>Capo</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SuperMegaUltraGroovy/Capo.download.recipe
+++ b/SuperMegaUltraGroovy/Capo.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SuperMegaUltraGroovy/FuzzMeasure.download.recipe
+++ b/SuperMegaUltraGroovy/FuzzMeasure.download.recipe
@@ -16,7 +16,7 @@
 		<string>FuzzMeasure</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/SuperMegaUltraGroovy/FuzzMeasure.download.recipe
+++ b/SuperMegaUltraGroovy/FuzzMeasure.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SuperMegaUltraGroovy/TapeDeck.download.recipe
+++ b/SuperMegaUltraGroovy/TapeDeck.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/SuperMegaUltraGroovy/TapeDeck.download.recipe
+++ b/SuperMegaUltraGroovy/TapeDeck.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://tapedeckapp.com/download/appcast-1.0.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TMNotifier/TMNotifier.download.recipe
+++ b/TMNotifier/TMNotifier.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/TMNotifier/TMNotifier.download.recipe
+++ b/TMNotifier/TMNotifier.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://tmnotifier.com/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TMNotifier/TMNotifier.download.recipe
+++ b/TMNotifier/TMNotifier.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://tmnotifier.com/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TableauReader/TableauReader.download.recipe
+++ b/TableauReader/TableauReader.download.recipe
@@ -26,7 +26,7 @@
 				<string>%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/TextBar/TextBar.download.recipe
+++ b/TextBar/TextBar.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.richsomerfield.com/apps/textbar/sparkle_textbar.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TextBar/TextBar.download.recipe
+++ b/TextBar/TextBar.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Thyme/Thyme.download.recipe
+++ b/Thyme/Thyme.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Thyme/Thyme.download.recipe
+++ b/Thyme/Thyme.download.recipe
@@ -16,7 +16,7 @@
 		<string>Thyme</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Thyme/Thyme.download.recipe
+++ b/Thyme/Thyme.download.recipe
@@ -16,7 +16,7 @@
 		<string>Thyme</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Toggl/TogglDesktop.download.recipe
+++ b/Toggl/TogglDesktop.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Toggl/TogglDesktop.download.recipe
+++ b/Toggl/TogglDesktop.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://assets.toggl.com/installers/darwin_stable_appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Toggl/TogglDesktop.download.recipe
+++ b/Toggl/TogglDesktop.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://assets.toggl.com/installers/darwin_stable_appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tor/TorBrowserBundle.download.recipe
+++ b/Tor/TorBrowserBundle.download.recipe
@@ -37,7 +37,7 @@
 				<string>https://dist.torproject.org/torbrowser/%version%/TorBrowser-%version%-osx64_%LANGUAGE%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tor/TorBrowserBundle.download.recipe
+++ b/Tor/TorBrowserBundle.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://dist.torproject.org/torbrowser/?C=N;O=D</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Tor/TorBrowserBundle.download.recipe
+++ b/Tor/TorBrowserBundle.download.recipe
@@ -14,7 +14,7 @@
 		<string>TorBrowserBundle</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tor/TorBrowserBundle.download.recipe
+++ b/Tor/TorBrowserBundle.download.recipe
@@ -14,7 +14,7 @@
 		<string>TorBrowserBundle</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tor/TorMessenger.download.recipe
+++ b/Tor/TorMessenger.download.recipe
@@ -37,7 +37,7 @@
 				<string>https://dist.torproject.org/tormessenger/%version%/%NAME%-%version%-osx64_%LANGUAGE%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tor/TorMessenger.download.recipe
+++ b/Tor/TorMessenger.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://dist.torproject.org/tormessenger/?C=M;O=D</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Tor/TorMessenger.download.recipe
+++ b/Tor/TorMessenger.download.recipe
@@ -14,7 +14,7 @@
 		<string>TorMessenger</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tor/TorMessenger.download.recipe
+++ b/Tor/TorMessenger.download.recipe
@@ -14,7 +14,7 @@
 		<string>TorMessenger</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tower/Tower.download.recipe
+++ b/Tower/Tower.download.recipe
@@ -16,7 +16,7 @@
 		<string>Tower</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tower/Tower.download.recipe
+++ b/Tower/Tower.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunabelly/DiskDiet.download.recipe
+++ b/Tunabelly/DiskDiet.download.recipe
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunabelly/DiskDiet.download.recipe
+++ b/Tunabelly/DiskDiet.download.recipe
@@ -18,7 +18,7 @@
 		<string>Mozilla/5.0</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunabelly/FolderTidy.download.recipe
+++ b/Tunabelly/FolderTidy.download.recipe
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunabelly/FolderTidy.download.recipe
+++ b/Tunabelly/FolderTidy.download.recipe
@@ -18,7 +18,7 @@
 		<string>Mozilla/5.0</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunabelly/HandsFree2.download.recipe
+++ b/Tunabelly/HandsFree2.download.recipe
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunabelly/HandsFree2.download.recipe
+++ b/Tunabelly/HandsFree2.download.recipe
@@ -18,7 +18,7 @@
 		<string>Mozilla/5.0</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunabelly/SilentStart.download.recipe
+++ b/Tunabelly/SilentStart.download.recipe
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunabelly/SilentStart.download.recipe
+++ b/Tunabelly/SilentStart.download.recipe
@@ -18,7 +18,7 @@
 		<string>Mozilla/5.0</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunabelly/TGPro.download.recipe
+++ b/Tunabelly/TGPro.download.recipe
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunabelly/TGPro.download.recipe
+++ b/Tunabelly/TGPro.download.recipe
@@ -18,7 +18,7 @@
 		<string>Mozilla/5.0</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TunnelBear/TunnelBear.download.recipe
+++ b/TunnelBear/TunnelBear.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/TunnelBear/TunnelBear.download.recipe
+++ b/TunnelBear/TunnelBear.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://s3.amazonaws.com/tunnelbear/downloads/mac/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunnelblick/Tunnelblick.download.recipe
+++ b/Tunnelblick/Tunnelblick.download.recipe
@@ -12,7 +12,7 @@
 		<string>Tunnelblick</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunnelblick/Tunnelblick.download.recipe
+++ b/Tunnelblick/Tunnelblick.download.recipe
@@ -12,7 +12,7 @@
 		<string>Tunnelblick</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Tunnelblick/Tunnelblick.download.recipe
+++ b/Tunnelblick/Tunnelblick.download.recipe
@@ -50,7 +50,7 @@
 				<string>https://tunnelblick.net/release/Tunnelblick_%version%_build_%build%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Tunnelblick/Tunnelblick.download.recipe
+++ b/Tunnelblick/Tunnelblick.download.recipe
@@ -26,7 +26,7 @@
 				<string>https://tunnelblick.net/downloads.html</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -39,7 +39,7 @@
 				<string>https://tunnelblick.net/downloads.html</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/UnRarX/UnRarX.download.recipe
+++ b/UnRarX/UnRarX.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.unrarx.com/update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/UnRarX/UnRarX.download.recipe
+++ b/UnRarX/UnRarX.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Unmarked/TextSoap.download.recipe
+++ b/Unmarked/TextSoap.download.recipe
@@ -16,7 +16,7 @@
 		<string>TextSoap</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Unmarked/TextSoap.download.recipe
+++ b/Unmarked/TextSoap.download.recipe
@@ -28,7 +28,7 @@
 				<string>http://unmarked.s3.amazonaws.com/textsoap%MAJOR_VERSION%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/ViennaRSS/Vienna.download.recipe
+++ b/ViennaRSS/Vienna.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://vienna-rss.org/spstats/changelog.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/ViennaRSS/Vienna.download.recipe
+++ b/ViennaRSS/Vienna.download.recipe
@@ -39,7 +39,7 @@
 				<string>%NAME%-%version%.tgz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/VimR/VimR.download.recipe
+++ b/VimR/VimR.download.recipe
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/VimR/VimR.download.recipe
+++ b/VimR/VimR.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://vimr.org/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VirtualC64/VirtualC64.download.recipe
+++ b/VirtualC64/VirtualC64.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VirtualC64/VirtualC64.download.recipe
+++ b/VirtualC64/VirtualC64.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/VirtualHost/VirtualHostX.download.recipe
+++ b/VirtualHost/VirtualHostX.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://shine.clickontyler.com/appcast.php?id=30</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VirtualHost/VirtualHostX.download.recipe
+++ b/VirtualHost/VirtualHostX.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Vox/Vox.download.recipe
+++ b/Vox/Vox.download.recipe
@@ -37,7 +37,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Vox/Vox.download.recipe
+++ b/Vox/Vox.download.recipe
@@ -18,7 +18,7 @@
 		<string>https://updates.devmate.com/com.coppertino.Vox.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VyprVPN/VyprVPN.download.recipe
+++ b/VyprVPN/VyprVPN.download.recipe
@@ -37,7 +37,7 @@
 				<string>https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/%version%/VyprVPN_v%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/VyprVPN/VyprVPN.download.recipe
+++ b/VyprVPN/VyprVPN.download.recipe
@@ -26,7 +26,7 @@
 				<string>https://www.goldenfrog.com/vyprvpn/mac-download</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/VyprVPN/VyprVPN.download.recipe
+++ b/VyprVPN/VyprVPN.download.recipe
@@ -12,7 +12,7 @@
 		<string>VyprVPN</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VyprVPN/VyprVPN.download.recipe
+++ b/VyprVPN/VyprVPN.download.recipe
@@ -12,7 +12,7 @@
 		<string>VyprVPN</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/WhatSize/WhatSize.download.recipe
+++ b/WhatSize/WhatSize.download.recipe
@@ -16,7 +16,7 @@
 		<string>WhatSize</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/WhatSize/WhatSize.download.recipe
+++ b/WhatSize/WhatSize.download.recipe
@@ -16,7 +16,7 @@
 		<string>WhatSize</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/WhatSize/WhatSize.download.recipe
+++ b/WhatSize/WhatSize.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/EasyBatchPhoto.download.recipe
+++ b/YellowMug/EasyBatchPhoto.download.recipe
@@ -16,7 +16,7 @@
 		<string>EasyBatchPhoto</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/EasyBatchPhoto.download.recipe
+++ b/YellowMug/EasyBatchPhoto.download.recipe
@@ -16,7 +16,7 @@
 		<string>EasyBatchPhoto</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/EasyBatchPhoto.download.recipe
+++ b/YellowMug/EasyBatchPhoto.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/EasyCrop.download.recipe
+++ b/YellowMug/EasyCrop.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/EasyCrop.download.recipe
+++ b/YellowMug/EasyCrop.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://yellowmug.com/easycrop/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/EasyCrop.download.recipe
+++ b/YellowMug/EasyCrop.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://yellowmug.com/easycrop/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/EasyFrame.download.recipe
+++ b/YellowMug/EasyFrame.download.recipe
@@ -16,7 +16,7 @@
 		<string>EasyFrame</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/EasyFrame.download.recipe
+++ b/YellowMug/EasyFrame.download.recipe
@@ -16,7 +16,7 @@
 		<string>EasyFrame</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/EasyFrame.download.recipe
+++ b/YellowMug/EasyFrame.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/FileChute.download.recipe
+++ b/YellowMug/FileChute.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/FileChute.download.recipe
+++ b/YellowMug/FileChute.download.recipe
@@ -16,7 +16,7 @@
 		<string>FileChute</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/FileChute.download.recipe
+++ b/YellowMug/FileChute.download.recipe
@@ -16,7 +16,7 @@
 		<string>FileChute</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/FolderBrander.download.recipe
+++ b/YellowMug/FolderBrander.download.recipe
@@ -16,7 +16,7 @@
 		<string>FolderBrander</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/FolderBrander.download.recipe
+++ b/YellowMug/FolderBrander.download.recipe
@@ -16,7 +16,7 @@
 		<string>FolderBrander</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/FolderBrander.download.recipe
+++ b/YellowMug/FolderBrander.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/SizzlingKeys.download.recipe
+++ b/YellowMug/SizzlingKeys.download.recipe
@@ -16,7 +16,7 @@
 		<string>SizzlingKeys</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/SizzlingKeys.download.recipe
+++ b/YellowMug/SizzlingKeys.download.recipe
@@ -16,7 +16,7 @@
 		<string>SizzlingKeys</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/SizzlingKeys.download.recipe
+++ b/YellowMug/SizzlingKeys.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/SnapNDrag.download.recipe
+++ b/YellowMug/SnapNDrag.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/YellowMug/SnapNDrag.download.recipe
+++ b/YellowMug/SnapNDrag.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://yellowmug.com/snapndrag/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/SnapNDrag.download.recipe
+++ b/YellowMug/SnapNDrag.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://yellowmug.com/snapndrag/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/YemuZip.download.recipe
+++ b/YellowMug/YemuZip.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification, because the current version of
 		<string>http://yellowmug.com/yemuzip/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/YemuZip.download.recipe
+++ b/YellowMug/YemuZip.download.recipe
@@ -18,7 +18,7 @@ Temporarily disabled code signature verification, because the current version of
 		<string>http://yellowmug.com/yemuzip/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/YellowMug/YemuZip.download.recipe
+++ b/YellowMug/YemuZip.download.recipe
@@ -37,7 +37,7 @@ Temporarily disabled code signature verification, because the current version of
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Zend/ZendStudio.download.recipe
+++ b/Zend/ZendStudio.download.recipe
@@ -30,7 +30,7 @@
 				<string>http://www.zend.com/en/products/studio/downloads-studio#Mac%20OS</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Zend/ZendStudio.download.recipe
+++ b/Zend/ZendStudio.download.recipe
@@ -16,7 +16,7 @@
 		<string>ZendStudio</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Zend/ZendStudio.download.recipe
+++ b/Zend/ZendStudio.download.recipe
@@ -16,7 +16,7 @@
 		<string>ZendStudio</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Zend/ZendStudio.download.recipe
+++ b/Zend/ZendStudio.download.recipe
@@ -41,7 +41,7 @@
 				<string>http://downloads.zend.com/studio-eclipse/%version%/ZendStudio-%version%-macosx.cocoa.x86_64.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Zoom/ZoomPresence.download.recipe
+++ b/Zoom/ZoomPresence.download.recipe
@@ -26,7 +26,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Zoom/ZoomPresence.download.recipe
+++ b/Zoom/ZoomPresence.download.recipe
@@ -16,7 +16,7 @@
 		<string>ZoomPresence</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/cdto/cdto.download.recipe
+++ b/cdto/cdto.download.recipe
@@ -14,7 +14,7 @@
 		<string>terminal</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/cdto/cdto.download.recipe
+++ b/cdto/cdto.download.recipe
@@ -28,7 +28,7 @@
 				<string>https://api.github.com/repos/jbtule/cdto/releases/latest</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/cdto/cdto.download.recipe
+++ b/cdto/cdto.download.recipe
@@ -46,7 +46,7 @@
 				<string>cdto-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/coconutBattery/coconutBattery.download.recipe
+++ b/coconutBattery/coconutBattery.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/coconutBattery/coconutBattery.download.recipe
+++ b/coconutBattery/coconutBattery.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://updates.coconut-flavour.com/coconutBatteryIntel.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iMazing/iMazing.download.recipe
+++ b/iMazing/iMazing.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/iMazing/iMazing.download.recipe
+++ b/iMazing/iMazing.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.devmate.com/com.DigiDNA.iMazingMac.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iMazing/iMazing.download.recipe
+++ b/iMazing/iMazing.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://updates.devmate.com/com.DigiDNA.iMazingMac.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iNotepad/iNotepad.download.recipe
+++ b/iNotepad/iNotepad.download.recipe
@@ -16,7 +16,7 @@
 		<string>iNotepad</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iNotepad/iNotepad.download.recipe
+++ b/iNotepad/iNotepad.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/iStumbler/iStumbler.download.recipe
+++ b/iStumbler/iStumbler.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/iStumbler/iStumbler.download.recipe
+++ b/iStumbler/iStumbler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://istumbler.net/feeds/appcast.rss</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iStumbler/iStumbler.download.recipe
+++ b/iStumbler/iStumbler.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://istumbler.net/feeds/appcast.rss</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iZip/iZip.download.recipe
+++ b/iZip/iZip.download.recipe
@@ -16,7 +16,7 @@
 		<string>iZip</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iZip/iZip.download.recipe
+++ b/iZip/iZip.download.recipe
@@ -16,7 +16,7 @@
 		<string>iZip</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/iZip/iZip.download.recipe
+++ b/iZip/iZip.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/miXscope/miXscope.download.recipe
+++ b/miXscope/miXscope.download.recipe
@@ -16,7 +16,7 @@
 		<string>miXscope</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/miXscope/miXscope.download.recipe
+++ b/miXscope/miXscope.download.recipe
@@ -16,7 +16,7 @@
 		<string>miXscope</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/miXscope/miXscope.download.recipe
+++ b/miXscope/miXscope.download.recipe
@@ -28,7 +28,7 @@
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/soma-zone/Ammonite.download.recipe
+++ b/soma-zone/Ammonite.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tbz</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/soma-zone/Ammonite.download.recipe
+++ b/soma-zone/Ammonite.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.soma-zone.com/Ammonite/a/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/soma-zone/BackupLoupe.download.recipe
+++ b/soma-zone/BackupLoupe.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.soma-zone.com/BackupLoupe/a/appcast_update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/soma-zone/BackupLoupe.download.recipe
+++ b/soma-zone/BackupLoupe.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tar.bz2</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/soma-zone/LaunchControl.download.recipe
+++ b/soma-zone/LaunchControl.download.recipe
@@ -16,7 +16,7 @@
 		<string>http://www.soma-zone.com/LaunchControl/a/appcast_update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/soma-zone/LaunchControl.download.recipe
+++ b/soma-zone/LaunchControl.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.tar.bz2</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/uBar/uBar.download.recipe
+++ b/uBar/uBar.download.recipe
@@ -16,7 +16,7 @@
 		<string>https://brawersoftware.com/appcasts/feeds/ubar/ubar3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.2</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/uBar/uBar.download.recipe
+++ b/uBar/uBar.download.recipe
@@ -35,7 +35,7 @@
 				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
Per AutoPkg 0.6.0 release notes:

> URLDownloader, URLTextSearcher and SparkleUpdateInfoProvider now all use the /usr/bin/curl binary for performing HTTP requests. This resolves several ongoing issues with Apple's Python urllib2 module and SSL. CURLDownloader and CURLTextSearcher processors refer internally to the same processors, and recipes using them can be safely switched back to the "standard" versions.