### PR TITLE
Update CCleaner.download.recipe

### DIFF
--- a/CCleaner/CCleaner.download.recipe
+++ b/CCleaner/CCleaner.download.recipe
@@ -33,8 +33,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>CCMacSetup109.dmg</string>
 				<key>url</key>
 				<string>https://download.piriform.com/%url%</string>
 			</dict>


### PR DESCRIPTION
Eliminate the Filename input on the URLDownloader Processer, which hardcodes and overrides to a (now) older version.