### PR TITLE
Using %NAME% for .app path in the CodeSignatureVerifier processer

### DIFF
--- a/BitTorrentSync/BitTorrentSync.download.recipe
+++ b/BitTorrentSync/BitTorrentSync.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/BitTorrent Sync.app</string>
 				<key>requirement</key>
 				<string>identifier "com.bittorrent.Sync" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SNBT6M4A7T</string>
 			</dict>


### PR DESCRIPTION
Using `%NAME%` for .app path in the CodeSignatureVerifier processer, make the CodeSignature fail when changing name in BitTorrentSync.munki.recipe