### PR TITLE
URLTextSearcher instead of Sparkle Feed

### DIFF
--- a/UnRarX/UnRarX.download.recipe
+++ b/UnRarX/UnRarX.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)
+	Code signature verification not possible. Code object not signed. No https download link available either.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of UnRarX.</string>
 	<key>Identifier</key>
@@ -12,30 +13,32 @@
 	<dict>
 		<key>NAME</key>
 		<string>UnRarX</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>http://www.unrarx.com/update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
+        	<dict>
+            		<key>Processor</key>
+            		<string>URLTextSearcher</string>
+            		<key>Arguments</key>
+            			<dict>
+                			<key>url</key>
+                			<string>http://www.unrarx.com/</string>
+                			<key>re_pattern</key>
+                			<string>(?P&lt;url&gt;http:\/\/www\.unrarx\.com\/files\/UnRarX_(?P&lt;version&gt;.*?)\.zip)</string>
+            			</dict>
+            	</dict>
+        	<dict>
+            		<key>Processor</key>
+            		<string>URLDownloader</string>
+            		<key>Arguments</key>
+            			<dict>
+               				<key>url</key>
+               				<string>%url%</string>
+               				<key>filename</key>
+               				<string>%NAME%-%version%.zip</string>
+            			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
To no longer pull the beta version down.