### PR TITLE
Tunnelblick: Support more minor stable versions.

### DIFF
--- a/Tunnelblick/Tunnelblick.download.recipe
+++ b/Tunnelblick/Tunnelblick.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>release/Tunnelblick_(?P&lt;version&gt;[\d\.]+a?)_build_(?P&lt;build&gt;[\d\.]+)\.dmg</string>
+				<string>release/Tunnelblick_(?P&lt;version&gt;[\d\.]+[a-z]?)_build_(?P&lt;build&gt;[\d\.]+)\.dmg</string>
 				<key>url</key>
 				<string>https://tunnelblick.net/downloads.html</string>
 			</dict>


### PR DESCRIPTION
Current regex string supports minor stable version updates up to `a`, like 3.6.7a.
Updated to support minor stable updates from `a-z`.