### PR TITLE
App name change to Cisco Proximity

### DIFF
--- a/Cisco/Proximity.download.recipe
+++ b/Cisco/Proximity.download.recipe
@@ -13,7 +13,7 @@
 		<key>DOWNLOAD_URL</key>
 		<string>https://proximity.cisco.com/mac/Proximity.dmg</string>
 		<key>NAME</key>
-		<string>Proximity</string>
+		<string>Cisco Proximity</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Cisco/Proximity.install.recipe
+++ b/Cisco/Proximity.install.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>Proximity</string>
+		<string>Cisco Proximity</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>

--- a/Cisco/Proximity.munki.recipe
+++ b/Cisco/Proximity.munki.recipe
@@ -13,7 +13,7 @@
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
-		<string>Proximity</string>
+		<string>Cisco Proximity</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>

--- a/Cisco/Proximity.pkg.recipe
+++ b/Cisco/Proximity.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>BUNDLE_ID</key>
 		<string>com.cisco.experimental.Proximity</string>
 		<key>NAME</key>
-		<string>Proximity</string>
+		<string>Cisco Proximity</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>


### PR DESCRIPTION
The pkg recipe (and thus, the JSS recipe) was failing because Cisco change the app name from "Proximity.app" to "Cisco Proximity.app". 

The failure was "Error in local.pkg.Proximity: Processor: Copier: Error: Error processing path '/private/tmp/dmg.gKobZ8/Proximity.app' with glob."

This will also require fixes to com.github.jss-recipes.jss.Proximity, which I will do in another PR. 

I was not able to test the munki recipe, but I assume it will work since only the name is being changed. Please confirm. 