### PR TITLE
Fix for Spotify's stupid permissions problems

### DIFF
--- a/Spotify/Spotify.pkg.recipe
+++ b/Spotify/Spotify.pkg.recipe
@@ -65,6 +65,8 @@
 							<string>Applications</string>
 							<key>user</key>
 							<string>root</string>
+							<key>mode</key>
+							<string>0755</string>
 						</dict>
 					</array>
 					<key>id</key>


### PR DESCRIPTION
Fix for the #104 where only the installing user (in this case root) can launch Spotify. This changes the permissions on the app structure so that any user can launch the app. No negative effects in my initial testing.