### PR TITLE
Update ForkLift SPARKLE_FEED_URL

### DIFF
--- a/BlackPixel/ForkLift.download.recipe
+++ b/BlackPixel/ForkLift.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>ForkLift</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://update.binarynights.com/ForkLift3/update.xml</string>
+		<string>https://updates.binarynights.com/ForkLift3/update.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
The old SPARKLE_FEED_URL URL was only Downloading Forklift Version 3.0 (http://download.binarynights.com/Test.zip) 

The new added SPARKLE_FEED_URL is the one the App itself is using for downloading updates. 
