### PR TITLE
Add postinstall script to secure Tunnelblick

### DIFF
--- a/Tunnelblick/Scripts/postinstall
+++ b/Tunnelblick/Scripts/postinstall
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# based on forum discussion:
+# https://groups.google.com/forum/#!topic/tunnelblick-discuss/UYeR7vv_rXM
+
+# setup folders and secure Tunnelblick app
+/Applications/Tunnelblick.app/Contents/Resources/installer 5
+
+# secure configurations
+/Applications/Tunnelblick.app/Contents/Resources/installer 16
+

--- a/Tunnelblick/Tunnelblick.munki.recipe
+++ b/Tunnelblick/Tunnelblick.munki.recipe
@@ -28,6 +28,17 @@
 			<string>Tunnelblick</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/sh
+# based on forum discussion:
+# https://groups.google.com/forum/#!topic/tunnelblick-discuss/UYeR7vv_rXM
+
+# setup folders and secure Tunnelblick app
+/Applications/Tunnelblick.app/Contents/Resources/installer 5
+
+# secure configurations
+/Applications/Tunnelblick.app/Contents/Resources/installer 16
+			</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Tunnelblick/Tunnelblick.pkg.recipe
+++ b/Tunnelblick/Tunnelblick.pkg.recipe
@@ -70,6 +70,8 @@
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<key>scripts</key>
+					<string>Scripts</string>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>


### PR DESCRIPTION
Currently Tunnelblick promopts for an admin password on first lanuch.
This presents a problem for users without admin rights.

A postinstall script performs the actions of securing Tunnelblick
and any configutions, so that admin rights are only needed during
the installation and not at first launch.