### PR TITLE
Update the GitHub desktop to use new client

### DIFF
--- a/GitHub/GitHubDesktop.download.recipe
+++ b/GitHub/GitHubDesktop.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://central.github.com/mac/latest</string>
+		<string>https://central.github.com/deployments/desktop/desktop/latest/darwin</string>
 		<key>NAME</key>
 		<string>GitHub Desktop</string>
 	</dict>


### PR DESCRIPTION
It appears the GitHub Desktop has switched over to the 'new native' client. I personally like the older one, but if you search for "Github desktop" this is what you get now.

This new client does appear to do away with the EA for versioning, so at least there's that.