### PR TITLE
GTM json URL has changed

### DIFF
--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -27,7 +27,7 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["GoToMeetingURLProvider"]
 
 
-BASE_URL = "https://p5.osdimg.com/g2mupdater/live/config.json"
+BASE_URL = "https://builds.cdn.getgo.com/g2mupdater/live/config.json"
 
 
 class GoToMeetingURLProvider(Processor):


### PR DESCRIPTION
If you visit the old URL, you get a message that the URL has changed. I confirmed that changing the BASE_URL value does get me the latest version of GTM downloaded.