### PR TITLE
Fix issue where %NAME% override causes download to fail

### DIFF
--- a/FindAnyFile/FindAnyFile.download.recipe
+++ b/FindAnyFile/FindAnyFile.download.recipe
@@ -71,7 +71,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Find Any File.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Follow the _CodeSignatureVerifier_ processor and specify the app filename in _Versioner_ so that an override to the %NAME% variable doesn't cause the recipe to fail.
(Perhaps a safer option might be to glob for the application name prior to _CodeSignatureVerifier_ and use the %found_filename% variable to construct the path inputs for the final two processors, or maybe this is overkill?!)