### PR TITLE
Use %NAME% substitution variable in all Processors

### DIFF
--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -38,7 +38,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Parallels Desktop.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4C6364ACXT")</string>
 			</dict>
@@ -49,7 +49,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Parallels Desktop.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -23,7 +23,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>ParallelsDesktop-%MAJOR_VERSION%.dmg</string>
+				<string>%NAME%-%MAJOR_VERSION%.dmg</string>
 				<key>url</key>
 				<string>https://www.parallels.com/directdownload/pd%MAJOR_VERSION%</string>
 			</dict>
@@ -38,7 +38,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Parallels Desktop.app</string>
+				<string>%pathname%/%NAME%.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4C6364ACXT")</string>
 			</dict>


### PR DESCRIPTION
This will allow for changing of %NAME% to successfully pass all through all Processors and Child Recipes.

In my environment, I'm labeling all the software that require a license as "<Software Title> Unlicensed-<version>" so our Site Admins know that the package does not contain a license and will need to apply one via another method (that's provided in the JSS).

This will help me do this without having to completely build my own Parallels recipe.