### PR TITLE
Replaced instances of %NAME%.app with actual name of apps

### DIFF
--- a/Anvil/Anvil.install.recipe
+++ b/Anvil/Anvil.install.recipe
@@ -39,7 +39,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Anvil.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/AuroraHDR/Aurora HDR Pro.install.recipe
+++ b/AuroraHDR/Aurora HDR Pro.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Aurora HDR Pro.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Automattic/WordPress.com.download.recipe
+++ b/Automattic/WordPress.com.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/WordPress.com.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Automattic/WordPress.com.install.recipe
+++ b/Automattic/WordPress.com.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>WordPress.com.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Automattic/WordPress.com.pkg.recipe
+++ b/Automattic/WordPress.com.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/WordPress.com.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/WordPress.com.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/BohemianCoding/Sketch.install.recipe
+++ b/BohemianCoding/Sketch.install.recipe
@@ -39,7 +39,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Sketch.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/C-Command/DropDMG.download.recipe
+++ b/C-Command/DropDMG.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/DropDMG.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/C-Command/DropDMG.install.recipe
+++ b/C-Command/DropDMG.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>DropDMG.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/C-Command/DropDMG.pkg.recipe
+++ b/C-Command/DropDMG.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/DropDMG.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/DropDMG.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/C-Command/EagleFiler.download.recipe
+++ b/C-Command/EagleFiler.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/EagleFiler.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/C-Command/EagleFiler.install.recipe
+++ b/C-Command/EagleFiler.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>EagleFiler.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/C-Command/EagleFiler.pkg.recipe
+++ b/C-Command/EagleFiler.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/EagleFiler.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/EagleFiler.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/C-Command/SpamSieve.download.recipe
+++ b/C-Command/SpamSieve.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/SpamSieve.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/C-Command/SpamSieve.install.recipe
+++ b/C-Command/SpamSieve.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SpamSieve.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/C-Command/SpamSieve.pkg.recipe
+++ b/C-Command/SpamSieve.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/SpamSieve.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/SpamSieve.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/CCleaner/CCleaner.install.recipe
+++ b/CCleaner/CCleaner.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>CCleaner.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/CCleaner/CCleaner.munki.recipe
+++ b/CCleaner/CCleaner.munki.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/CCleaner.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/CCleaner/CCleaner.pkg.recipe
+++ b/CCleaner/CCleaner.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/CCleaner.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/CCleaner.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/CCleaner.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Caffeine/Caffeine.install.recipe
+++ b/Caffeine/Caffeine.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Caffeine.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cakebrew/Cakebrew.download.recipe
+++ b/Cakebrew/Cakebrew.download.recipe
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Cakebrew.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Cakebrew/Cakebrew.install.recipe
+++ b/Cakebrew/Cakebrew.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cakebrew.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cakebrew/Cakebrew.pkg.recipe
+++ b/Cakebrew/Cakebrew.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Cakebrew.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Cakebrew.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Celestia/Celestia.install.recipe
+++ b/Celestia/Celestia.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Celestia.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Celestia/Celestia.pkg.recipe
+++ b/Celestia/Celestia.pkg.recipe
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Celestia.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Celestia.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/CharlesSoft/CocoaTADS.install.recipe
+++ b/CharlesSoft/CocoaTADS.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>CocoaTADS.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/CharlesSoft/CocoaTADS.pkg.recipe
+++ b/CharlesSoft/CocoaTADS.pkg.recipe
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/CocoaTADS.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -61,9 +61,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/CocoaTADS.app</string>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/CocoaTADS.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/CharlesSoft/NibUnlocker.install.recipe
+++ b/CharlesSoft/NibUnlocker.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>NibUnlocker.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/CharlesSoft/NibUnlocker.pkg.recipe
+++ b/CharlesSoft/NibUnlocker.pkg.recipe
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/NibUnlocker.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/CharlesSoft/TimeTracker.install.recipe
+++ b/CharlesSoft/TimeTracker.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>TimeTracker.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/CharlesSoft/TimeTracker.pkg.recipe
+++ b/CharlesSoft/TimeTracker.pkg.recipe
@@ -50,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/TimeTracker.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Cisco/Proximity.install.recipe
+++ b/Cisco/Proximity.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cisco Proximity.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cisco/Proximity.pkg.recipe
+++ b/Cisco/Proximity.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Cisco Proximity.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Cisco Proximity.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Cocktail/Cocktail-10.10.install.recipe
+++ b/Cocktail/Cocktail-10.10.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cocktail.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cocktail/Cocktail-10.6.install.recipe
+++ b/Cocktail/Cocktail-10.6.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cocktail.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cocktail/Cocktail-10.7.install.recipe
+++ b/Cocktail/Cocktail-10.7.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cocktail.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cocktail/Cocktail-10.8.install.recipe
+++ b/Cocktail/Cocktail-10.8.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cocktail.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Cocktail/Cocktail-10.9.install.recipe
+++ b/Cocktail/Cocktail-10.9.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cocktail.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Deltopia/DeltaWalker.install.recipe
+++ b/Deltopia/DeltaWalker.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>DeltaWalker.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Deltopia/DeltaWalker.pkg.recipe
+++ b/Deltopia/DeltaWalker.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/DeltaWalker.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/DeltaWalker.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/DevonTechnologies/DEVONthinkPro.download.recipe
+++ b/DevonTechnologies/DEVONthinkPro.download.recipe
@@ -69,7 +69,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/DEVONthink Pro.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/DevonTechnologies/DEVONthinkProOffice.download.recipe
+++ b/DevonTechnologies/DEVONthinkProOffice.download.recipe
@@ -69,7 +69,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/DEVONthink Pro.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Divvy/Divvy.install.recipe
+++ b/Divvy/Divvy.install.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Divvy.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -74,7 +74,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Divvy.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Divvy/Divvy.pkg.recipe
+++ b/Divvy/Divvy.pkg.recipe
@@ -61,7 +61,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Divvy.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Endurance/Endurance.install.recipe
+++ b/Endurance/Endurance.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Endurance.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/FatCatSoftware/PowerPhotos.download.recipe
+++ b/FatCatSoftware/PowerPhotos.download.recipe
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/PowerPhotos.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/FatCatSoftware/PowerPhotos.install.recipe
+++ b/FatCatSoftware/PowerPhotos.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>PowerPhotos.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/FindAnyFile/FindAnyFile.install.recipe
+++ b/FindAnyFile/FindAnyFile.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Find Any File.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Flux/Flux.install.recipe
+++ b/Flux/Flux.install.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Flux.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -74,7 +74,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Flux.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Flux/Flux.pkg.recipe
+++ b/Flux/Flux.pkg.recipe
@@ -61,7 +61,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Flux.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Gitify/Gitify.download.recipe
+++ b/Gitify/Gitify.download.recipe
@@ -69,7 +69,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Gitify.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Gitify/Gitify.install.recipe
+++ b/Gitify/Gitify.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Gitify.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Grammarly/Grammarly.download.recipe
+++ b/Grammarly/Grammarly.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Grammarly.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Grammarly/Grammarly.install.recipe
+++ b/Grammarly/Grammarly.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Grammarly.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Grammarly/Grammarly.pkg.recipe
+++ b/Grammarly/Grammarly.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Grammarly.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Grammarly.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/GrandPerspective/GrandPerspective.install.recipe
+++ b/GrandPerspective/GrandPerspective.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>GrandPerspective.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/GrandPerspective/GrandPerspective.pkg.recipe
+++ b/GrandPerspective/GrandPerspective.pkg.recipe
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/GrandPerspective.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/GrandPerspective.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Helium/Helium.install.recipe
+++ b/Helium/Helium.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Helium.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Helium/Helium.pkg.recipe
+++ b/Helium/Helium.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Helium.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/KeePassX/KeePassX.install.recipe
+++ b/KeePassX/KeePassX.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>KeePassX.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/KeePassX/KeePassX.pkg.recipe
+++ b/KeePassX/KeePassX.pkg.recipe
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/KeePassX.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/KeePassX.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/MacPaw/CleanMyMac3-beta.download.recipe
+++ b/MacPaw/CleanMyMac3-beta.download.recipe
@@ -64,7 +64,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/CleanMyMac 3.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/MacPaw/CleanMyMac3-beta.install.recipe
+++ b/MacPaw/CleanMyMac3-beta.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>CleanMyMac 3.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/MacPaw/Gemini2.download.recipe
+++ b/MacPaw/Gemini2.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Gemini 2.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/MacPaw/Gemini2.install.recipe
+++ b/MacPaw/Gemini2.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Gemini 2.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/MacPaw/Gemini2.pkg.recipe
+++ b/MacPaw/Gemini2.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Gemini 2.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Gemini 2.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/MacRabbit/Slicy.download.recipe
+++ b/MacRabbit/Slicy.download.recipe
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Slicy.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/MacTerm/MacTerm.download.recipe
+++ b/MacTerm/MacTerm.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/MacTerm.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/MacTerm/MacTerm.install.recipe
+++ b/MacTerm/MacTerm.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>MacTerm.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/MacTerm/MacTerm.pkg.recipe
+++ b/MacTerm/MacTerm.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/MacTerm.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/MacTerm.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Mailplane/Mailplane3.install.recipe
+++ b/Mailplane/Mailplane3.install.recipe
@@ -74,7 +74,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Mailplane.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/MarinerSoftware/Persona.download.recipe
+++ b/MarinerSoftware/Persona.download.recipe
@@ -60,9 +60,9 @@
 				<key>purge_destination</key>
 				<true/>
 				<key>source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Users/bill/Desktop/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Users/bill/Desktop/Persona.app</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Persona.app</string>
 			</dict>
 			<key>Comment</key>
 			<string>For some reason, the app is buried inside a Users folder when the app is extracted. In order to proceed with the remaining recipes, we must move the app to the proper place.</string>

--- a/Marked/Marked2.install.recipe
+++ b/Marked/Marked2.install.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Marked 2.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -76,7 +76,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Marked 2.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Marked/Marked2.pkg.recipe
+++ b/Marked/Marked2.pkg.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Marked 2.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/NetSurf/NetSurf.install.recipe
+++ b/NetSurf/NetSurf.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>NetSurf.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/NetSurf/NetSurf.munki.recipe
+++ b/NetSurf/NetSurf.munki.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/NetSurf.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/NetSurf/NetSurf.pkg.recipe
+++ b/NetSurf/NetSurf.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/NetSurf.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/NetSurf.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/NetSurf.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/ObjectiveDevelopment/LaunchBar.install.recipe
+++ b/ObjectiveDevelopment/LaunchBar.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>LaunchBar.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/ObjectiveDevelopment/LaunchBar.pkg.recipe
+++ b/ObjectiveDevelopment/LaunchBar.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/LaunchBar.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/LaunchBar.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Papers/Papers.install.recipe
+++ b/Papers/Papers.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Papers.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Papers/Papers.pkg.recipe
+++ b/Papers/Papers.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Papers.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Papers.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -30,7 +30,7 @@
 			<string>%NAME%</string>
 			<key>postinstall_script</key>
 			<string>#!/bin/bash
-chflags nohidden "/Applications/%NAME%.app"
+chflags nohidden "/Applications/Parallels Desktop.app"
             </string>
 			<key>unattended_install</key>
 			<true/>
@@ -46,11 +46,11 @@ chflags nohidden "/Applications/%NAME%.app"
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Parallels Desktop.app</string>
 				<key>overwrite</key>
 				<true/>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Parallels Desktop.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Polymail/Polymail.install.recipe
+++ b/Polymail/Polymail.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Polymail.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Postbox/Postbox.install.recipe
+++ b/Postbox/Postbox.install.recipe
@@ -37,7 +37,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Postbox.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Postbox/Postbox.pkg.recipe
+++ b/Postbox/Postbox.pkg.recipe
@@ -46,9 +46,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Postbox.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Postbox.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/PublicSpace/VitaminR.install.recipe
+++ b/PublicSpace/VitaminR.install.recipe
@@ -39,7 +39,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Vitamin-R 2.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/PublicSpace/VitaminR.pkg.recipe
+++ b/PublicSpace/VitaminR.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Vitamin-R 2.app</string>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Vitamin-R 2.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Quicksilver/Quicksilver.install.recipe
+++ b/Quicksilver/Quicksilver.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Quicksilver.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Quip/Quip.install.recipe
+++ b/Quip/Quip.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Quip.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Quip/Quip.pkg.recipe
+++ b/Quip/Quip.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Quip.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Quip.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Reinvented/Feeder.install.recipe
+++ b/Reinvented/Feeder.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Feeder 3.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Reinvented/Feeder.pkg.recipe
+++ b/Reinvented/Feeder.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Feeder 3.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Feeder 3.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Reinvented/Together.install.recipe
+++ b/Reinvented/Together.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Together 3.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Reinvented/Together.pkg.recipe
+++ b/Reinvented/Together.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Together 3.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Together 3.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Renamer/Renamer.download.recipe
+++ b/Renamer/Renamer.download.recipe
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Renamer.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Renamer/Renamer.install.recipe
+++ b/Renamer/Renamer.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Renamer.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Revisions/Revisions.install.recipe
+++ b/Revisions/Revisions.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Revisions.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Revisions/Revisions.munki.recipe
+++ b/Revisions/Revisions.munki.recipe
@@ -40,7 +40,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Revisions.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Revisions/Revisions.pkg.recipe
+++ b/Revisions/Revisions.pkg.recipe
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Revisions.app</string>
 				<key>source_path</key>
 				<string>%pathname%/Revisions.app</string>
 			</dict>

--- a/Royal/RoyalTSX.install.recipe
+++ b/Royal/RoyalTSX.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Royal TSX.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Royal/RoyalTSX.pkg.recipe
+++ b/Royal/RoyalTSX.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Royal TSX.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Royal TSX.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Royal TSX.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Shimo/Shimo.download.recipe
+++ b/Shimo/Shimo.download.recipe
@@ -75,7 +75,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Shimo.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Shimo/Shimo.install.recipe
+++ b/Shimo/Shimo.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Shimo.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/ShirtPocket/SuperDuper.install.recipe
+++ b/ShirtPocket/SuperDuper.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SuperDuper!.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/ShirtPocket/SuperDuper.pkg.recipe
+++ b/ShirtPocket/SuperDuper.pkg.recipe
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/SuperDuper!.app</string>
 				<key>source_path</key>
 				<string>%pathname%/SuperDuper!.app</string>
 			</dict>

--- a/Simon/Simon.download.recipe
+++ b/Simon/Simon.download.recipe
@@ -69,7 +69,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Simon.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Simon/Simon.install.recipe
+++ b/Simon/Simon.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Simon.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/SizeUp/SizeUp.install.recipe
+++ b/SizeUp/SizeUp.install.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SizeUp.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -74,7 +74,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SizeUp.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/SizeUp/SizeUp.pkg.recipe
+++ b/SizeUp/SizeUp.pkg.recipe
@@ -61,7 +61,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SizeUp.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/SnapGene/SnapGeneViewer.install.recipe
+++ b/SnapGene/SnapGeneViewer.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SnapGene Viewer.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/SnapGene/SnapGeneViewer.munki.recipe
+++ b/SnapGene/SnapGeneViewer.munki.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/SnapGene Viewer.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/SnapGene/SnapGeneViewer.pkg.recipe
+++ b/SnapGene/SnapGeneViewer.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/SnapGene Viewer.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/SnapGene Viewer.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/SnapGene Viewer.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Spotify/Spotify.install.recipe
+++ b/Spotify/Spotify.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Spotify.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/StairwaysSoftware/KeyboardMaestro.download.recipe
+++ b/StairwaysSoftware/KeyboardMaestro.download.recipe
@@ -71,7 +71,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Keyboard Maestro.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/StairwaysSoftware/KeyboardMaestro.install.recipe
+++ b/StairwaysSoftware/KeyboardMaestro.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Keyboard Maestro.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Stand/Stand.download.recipe
+++ b/Stand/Stand.download.recipe
@@ -67,7 +67,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Stand.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Stand/Stand.install.recipe
+++ b/Stand/Stand.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Stand.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/SuperMegaUltraGroovy/FuzzMeasure.download.recipe
+++ b/SuperMegaUltraGroovy/FuzzMeasure.download.recipe
@@ -71,7 +71,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/FuzzMeasure.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/SuperMegaUltraGroovy/FuzzMeasure.install.recipe
+++ b/SuperMegaUltraGroovy/FuzzMeasure.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>FuzzMeasure.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Thyme/Thyme.install.recipe
+++ b/Thyme/Thyme.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Thyme.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Thyme/Thyme.munki.recipe
+++ b/Thyme/Thyme.munki.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Thyme.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Thyme/Thyme.pkg.recipe
+++ b/Thyme/Thyme.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Thyme.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Thyme.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Thyme.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Tor/TorMessenger.install.recipe
+++ b/Tor/TorMessenger.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Tor Messenger.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tor/TorMessenger.pkg.recipe
+++ b/Tor/TorMessenger.pkg.recipe
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Tor Messenger.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Tor Messenger.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Tunabelly/DiskDiet.download.recipe
+++ b/Tunabelly/DiskDiet.download.recipe
@@ -81,7 +81,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Disk Diet.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Tunabelly/DiskDiet.install.recipe
+++ b/Tunabelly/DiskDiet.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Disk Diet.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tunabelly/FolderTidy.download.recipe
+++ b/Tunabelly/FolderTidy.download.recipe
@@ -81,7 +81,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Folder Tidy.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Tunabelly/FolderTidy.install.recipe
+++ b/Tunabelly/FolderTidy.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Folder Tidy.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tunabelly/HandsFree2.download.recipe
+++ b/Tunabelly/HandsFree2.download.recipe
@@ -81,7 +81,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/HandsFree 2.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Tunabelly/HandsFree2.install.recipe
+++ b/Tunabelly/HandsFree2.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>HandsFree 2.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tunabelly/SilentStart.download.recipe
+++ b/Tunabelly/SilentStart.download.recipe
@@ -81,7 +81,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Silent Start.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Tunabelly/SilentStart.install.recipe
+++ b/Tunabelly/SilentStart.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Silent Start.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tunabelly/TGPro.download.recipe
+++ b/Tunabelly/TGPro.download.recipe
@@ -81,7 +81,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/TG Pro.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Tunabelly/TGPro.install.recipe
+++ b/Tunabelly/TGPro.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>TG Pro.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tunnelblick/Tunnelblick.install.recipe
+++ b/Tunnelblick/Tunnelblick.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Tunnelblick.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tunnelblick/Tunnelblick.pkg.recipe
+++ b/Tunnelblick/Tunnelblick.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Tunnelblick.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Tunnelblick.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/VyprVPN/VyprVPN.install.recipe
+++ b/VyprVPN/VyprVPN.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>VyprVPN.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/VyprVPN/VyprVPN.munki.recipe
+++ b/VyprVPN/VyprVPN.munki.recipe
@@ -51,9 +51,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/%NAME%.app</string>
+				<string>%pkgroot%/VyprVPN.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/VyprVPN.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/VyprVPN/VyprVPN.pkg.recipe
+++ b/VyprVPN/VyprVPN.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/VyprVPN.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/VyprVPN.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Waltr/Waltr.download.recipe
+++ b/Waltr/Waltr.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Waltr.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Waltr/Waltr.install.recipe
+++ b/Waltr/Waltr.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Waltr.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Waltr/Waltr.pkg.recipe
+++ b/Waltr/Waltr.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Waltr.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Waltr.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/WhatSize/WhatSize.download.recipe
+++ b/WhatSize/WhatSize.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/WhatSize.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/WhatSize/WhatSize.install.recipe
+++ b/WhatSize/WhatSize.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>WhatSize.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/WhatSize/WhatSize.pkg.recipe
+++ b/WhatSize/WhatSize.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/WhatSize.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/WhatSize.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/YellowMug/SnapNDrag.install.recipe
+++ b/YellowMug/SnapNDrag.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SnapNDrag.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/YellowMug/SnapNDrag.pkg.recipe
+++ b/YellowMug/SnapNDrag.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/SnapNDrag.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -50,9 +50,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/SnapNDrag.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/SnapNDrag.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Zoom/ZoomPresence.munki.recipe
+++ b/Zoom/ZoomPresence.munki.recipe
@@ -18,7 +18,7 @@
 		<dict>
 			<key>blocking_applications</key>
 			<array>
-				<string>%NAME%.app</string>
+				<string>ZoomPresence.app</string>
 			</array>
 			<key>catalogs</key>
 			<array>

--- a/cdto/cdto.download.recipe
+++ b/cdto/cdto.download.recipe
@@ -80,7 +80,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpacked/%dirname%/%TERMINAL_APP%/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/%dirname%/%TERMINAL_APP%/cd to.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/cdto/cdto.munki.recipe
+++ b/cdto/cdto.munki.recipe
@@ -42,11 +42,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/cd to.app</string>
 				<key>overwrite</key>
 				<true/>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpacked/%dirname%/%TERMINAL_APP%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/%dirname%/%TERMINAL_APP%/cd to.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/cdto/cdto.pkg.recipe
+++ b/cdto/cdto.pkg.recipe
@@ -25,11 +25,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/cd to.app</string>
 				<key>overwrite</key>
 				<true/>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpacked/%dirname%/%TERMINAL_APP%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/%dirname%/%TERMINAL_APP%/cd to.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
This should prevent overriding NAME from breaking the recipes. (See #137 and #138.)