### PR TITLE
Updated Sparkle feed URL.

### DIFF
--- a/Clarify/Clarify.download.recipe
+++ b/Clarify/Clarify.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>Clarify</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>https://www.bluemangolearning.com/download/clarify/2_0/auto_update/release/clarify_appcast.xml</string>
+		<string>http://files.clarify-it.com/v2/updaters/release/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
It looks like the Clarify sparkle feed change, but the old one is still around serving v2.0.7, so no one was getting errors. I've updated the feed to the new URL http://files.clarify-it.com/v2/updaters/release/appcast.xml that's serving up the latest version: v2.0.11.