### PR TITLE
Fix parent recipe id

### DIFF
--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -16,7 +16,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.hansen-m.download.zoom</string>
+	<string>com.github.hansen-m.download.zoomus</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Parent recipe ID has changed slightly from `..download.zoom` to `..download.zoomus` :)