### PR TITLE
Collect the correct app version

### DIFF
--- a/AirDroid/AirDroid.download.recipe
+++ b/AirDroid/AirDroid.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_plist_path</key>
 				<string>%pathname%/AirDroid.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>


### PR DESCRIPTION
CFBundleVersion collects a different version number that is not reflected when getting info on the app

![screenshot 2018-03-05 21 36 44](https://user-images.githubusercontent.com/11789931/37011255-51b981ec-20bd-11e8-8370-ad78768ea478.png)
