### PR TITLE
Fixed regex search for the URL.

### DIFF
--- a/Egnyte/EgnyteDesktopSync.download.recipe
+++ b/Egnyte/EgnyteDesktopSync.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>"https:\/\/egnyte-cdn\.egnyte\.com\/desktopsync\/mac\/%LOCALE%\/(?P&lt;version&gt;[\d\.]+)\/EgnyteDesktopSync_[\d\.]+_(?P&lt;build&gt;[\w]+)\.pkg"</string>
+				<string>"(?P&lt;protocol&gt;[\w]+):\/\/egnyte-cdn\.egnyte\.com\/desktopsync\/mac\/%LOCALE%\/(?P&lt;version&gt;[\d\.]+)\/EgnyteDesktopSync_[\d\.]+_(?P&lt;build&gt;[\w]+)\.pkg"</string>
 				<key>url</key>
 				<string>https://helpdesk.egnyte.com/hc/%LOCALE%/articles/201636844</string>
 			</dict>
@@ -34,7 +34,7 @@
 				<key>filename</key>
 				<string>EgnyteDesktopSync-%version%.pkg</string>
 				<key>url</key>
-				<string>https://egnyte-cdn.egnyte.com/desktopsync/mac/%LOCALE%/%version%/EgnyteDesktopSync_%version%_%build%.pkg</string>
+				<string>%protocol%://egnyte-cdn.egnyte.com/desktopsync/mac/%LOCALE%/%version%/EgnyteDesktopSync_%version%_%build%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The regex search for Egnyte Desktop's download URL was failing. It was looking for https:// but the latest URL is http://. I've updated the regex to search for the protocol, put that into the "protocol" variable, and then use %protocol% in the download URL. This should allow it to match http:// and https://.