### PR TITLE
Adding find and replace to VersionSplitter

### DIFF
--- a/VersionSplitter/README.md
+++ b/VersionSplitter/README.md
@@ -1,6 +1,8 @@
 # VersionSplitter
 
-This processor splits version numbers. This is especially useful if the version contains two parts (e.g. version and build) but you only need/want one of them.
+This processor splits version numbers, and can also find and replace within `version`. 
+
+Splitting the version is especially useful if the version contains two parts (e.g. version and build) but you only need/want one of them.
 
 ## Example 1
 
@@ -55,3 +57,15 @@ You can also return a part of the version other than the first part. For example
 
 - Example 3 `version` input: `macosx_64bit_3.0`
 - Example 3 `version` output: `3.0`
+
+#Find and replace
+This processor can also find and replace a part of `version`. For instance, if the version for Docker is `18.03.0-ce-mac59`, we can find for `-ce-mac` and replace it with `.`. This would produce a version of `18.03.0.59`.
+
+```
+<dict>
+    <key>find</key>
+    <string>-ce-mac</string>
+    <key>replace</key>
+    <string>.</string>
+</dict>
+```

--- a/VersionSplitter/README.md
+++ b/VersionSplitter/README.md
@@ -58,7 +58,8 @@ You can also return a part of the version other than the first part. For example
 - Example 3 `version` input: `macosx_64bit_3.0`
 - Example 3 `version` output: `3.0`
 
-#Find and replace
+## Find and replace
+
 This processor can also find and replace a part of `version`. For instance, if the version for Docker is `18.03.0-ce-mac59`, we can find for `-ce-mac` and replace it with `.`. This would produce a version of `18.03.0.59`.
 
 ```

--- a/VersionSplitter/VersionSplitter.py
+++ b/VersionSplitter/VersionSplitter.py
@@ -42,6 +42,17 @@ class VersionSplitter(Processor):
             "description": "The character(s) to use for splitting the "
                            "version. (Defaults to a space.)"
         },
+        "find": {
+            "required": False,
+            "description": "The character(s) to find in the "
+                           "version. Used with 'replace'."
+        },
+        "replace": {
+            "required": False,
+            "description": "The character(s) to replace in the "
+                           "version. Works with 'find'. "
+                           "(Defaults to a decimal point.)"
+        },
         "index": {
             "required": False,
             "description": "The index of the version string to be "
@@ -56,7 +67,10 @@ class VersionSplitter(Processor):
     description = __doc__
 
     def main(self):
-
+        find = self.env.get("find", "")
+        if find:
+            replace = self.env.get("replace")
+            self.env["version"] = self.env["version"].replace(find, replace)
         split_on = self.env.get("split_on", " ")
         index = self.env.get("index", 0)
         self.env["version"] = self.env["version"].split(split_on)[index]

--- a/VersionSplitter/VersionSplitter.py
+++ b/VersionSplitter/VersionSplitter.py
@@ -67,10 +67,9 @@ class VersionSplitter(Processor):
     description = __doc__
 
     def main(self):
-        find = self.env.get("find", "")
-        if find:
-            replace = self.env.get("replace")
-            self.env["version"] = self.env["version"].replace(find, replace)
+        if self.env.get("find"):
+            replace = self.env.get("replace", ".")
+            self.env["version"] = self.env["version"].replace(self.env.get("find"), replace)
         split_on = self.env.get("split_on", " ")
         index = self.env.get("index", 0)
         self.env["version"] = self.env["version"].split(split_on)[index]


### PR DESCRIPTION
Ran into an issue with Docker.pkg where the existing recipe using VersionSplitter would never repackage as it was stripping minor version info, due to Docker's odd versioning (18.03.0-ce-mac59). After exhausting existing processor options, I modified this one to allow for a string substitution.