### PR TITLE
Update JSSImporter.download.recipe

### DIFF
--- a/JSSImporter/JSSImporter.download.recipe
+++ b/JSSImporter/JSSImporter.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>
-				<string>sheagcraig/JSSImporter</string>
+				<string>jssimporter/JSSImporter</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
JSSImporter is now part of the https://github.com/jssimporter organization, and the releases have been moved to `jssimporter/JSSImporter`.