### PR TITLE
Remove repacking of R from pkg to dmg

### DIFF
--- a/R/R.munki.recipe
+++ b/R/R.munki.recipe
@@ -39,19 +39,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
The R.munki.recipe previously would encapsulate the downloaded pkg file
into a dmg file without making any other alterations. However, the
source for the dmg file was %RECIPE_CACHE_DIR%/downloads and this
directory often contains not only the current pkg file, but also
old pkg files from previous versions of R. When multiple pkg files are
present, they all end up in the dmg file and makepkginfo gets rather
confused about what version of R is contained in the dmg.

I have removed the pkg to dmg conversion from R.munki.recipe, which
solves the above problem.