### PR TITLE
Added CHECK_FILESIZE_ONLY to UrlDownloader

### DIFF
--- a/GoToMeeting/GoToMeeting.download.recipe
+++ b/GoToMeeting/GoToMeeting.download.recipe
@@ -22,6 +22,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>CHECK_FILESIZE_ONLY</key>
+                                <true/>
 				<key>filename</key>
 				<string>%NAME%.tar.gz</string>
 				<key>url</key>


### PR DESCRIPTION
Added CHECK_FILESIZE_ONLY to UrlDownloader as AutoPkg always notify for a new version and the ETag header is even different - mirrors?