### PR TITLE
Fix "Tor Browser" name. In < 8.0 was "TorBrowser".

### DIFF
--- a/Tor/TorBrowserBundle.download.recipe
+++ b/Tor/TorBrowserBundle.download.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/TorBrowser.app</string>
+				<string>%pathname%/Tor Browser.app</string>
 				<key>requirement</key>
 				<string>identifier "org.torproject.torbrowser" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MADPSAYN6T</string>
 			</dict>

--- a/Tor/TorBrowserBundle.pkg.recipe
+++ b/Tor/TorBrowserBundle.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/tmp/TorBrowser.app</string>
+				<string>%pkgroot%/tmp/Tor Browser.app</string>
 				<key>source_path</key>
-				<string>%pathname%/TorBrowser.app</string>
+				<string>%pathname%/Tor Browser.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
In 8.0 and 8.0.1, is now "Tor Browser.app". Fixes #182 