### PR TITLE
Use Tor ?C=M;O=D to get latest patch version.

### DIFF
--- a/Tor/TorBrowserBundle.download.recipe
+++ b/Tor/TorBrowserBundle.download.recipe
@@ -25,7 +25,7 @@
 				<key>result_output_var_name</key>
 				<string>version</string>
 				<key>url</key>
-				<string>https://dist.torproject.org/torbrowser/?C=N;O=D</string>
+				<string>https://dist.torproject.org/torbrowser/?C=M;O=D</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
This fixes #184 by re-ordering https://dist.torproject.org/torbrowser based on modified date descending, allowing 8.0.1 to appear first, above 8.0.