### PR TITLE
Update ApacheDirectoryStudio.munki.recipe

### DIFF
--- a/Apache/ApacheDirectoryStudio.munki.recipe
+++ b/Apache/ApacheDirectoryStudio.munki.recipe
@@ -54,6 +54,8 @@
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
The CFBundleShortVersionString is 2.0.0, while the CFBundleVersion current value is 2.0.0.v20180908-M14. When running the AutoPkg MUNKI recipe, while the new version is downloaded, the app is not updated in the MUNKI repo because version 2.0.0 is already present.