### PR TITLE
Update name of TorBrowser.app in postinstall

### DIFF
--- a/Tor/TorBrowserBundleScripts/postinstall
+++ b/Tor/TorBrowserBundleScripts/postinstall
@@ -11,7 +11,7 @@ if [[ ! -d "$USER_APPS" ]]; then
     chmod -R 700 "$USER_APPS"
 fi
 
-mv "$3/tmp/TorBrowser.app" "$USER_APPS/TorBrowser.app"
+mv "$3/tmp/Tor Browser.app" "$USER_APPS/TorBrowser.app"
 chown -R "$CURRENT_USER:staff" "$USER_APPS/TorBrowser.app"
 
 exit 0


### PR DESCRIPTION
Related to #182 and its fix, #183. The postinstall script still targets the old name.

This probably went unnoticed as long as it did since installs are marked successful even if postinstall scripts fail.