### PR TITLE
Changed the input_path for CodeSignatureVerifier

### DIFF
--- a/Smultron/Smultron.download.recipe
+++ b/Smultron/Smultron.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>9</string>
+		<string>10</string>
 		<key>NAME</key>
 		<string>Smultron</string>
 	</dict>
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Smultron %MAJOR_VERSION%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Smultron*.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.peterborgapps.Smultron%MAJOR_VERSION%" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HT76L9L9RG)</string>
 			</dict>


### PR DESCRIPTION
This is to work better with v10 which doesn't have the version number in the App name