### PR TITLE
Drop installcheck_script from TorBrowserBundle

### DIFF
--- a/Tor/TorBrowserBundle.munki.recipe
+++ b/Tor/TorBrowserBundle.munki.recipe
@@ -26,15 +26,6 @@
 			<string>The Tor Project, Inc.</string>
 			<key>display_name</key>
 			<string>%DISPLAY_NAME%</string>
-			<key>installcheck_script</key>
-			<string>#!/bin/bash
-CURRENT_USER=$(/usr/bin/stat -f%Su /dev/console)
-USER_APPS="/Users/$CURRENT_USER/Applications"
-if [[ -d "$USER_APPS/TorBrowser.app" ]]; then
-    exit 1
-fi
-exit 0
-            </string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
The script used only tests that *any* install exists, so the application currently isn't updating. Dropping the `installcheck_script` altogether allows Munki to fall back to receipts, which works in my test environment.