### PR TITLE
Updated Royal TSX download recipe for new domain

### DIFF
--- a/Royal/RoyalTSX.download.recipe
+++ b/Royal/RoyalTSX.download.recipe
@@ -21,11 +21,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>href="(https://royaltsx-v4.royalapplications.com/updates/royaltsx_.+\.dmg)" title="Download Royal TSX"&gt;Download Now&lt;/a&gt;</string>
+				<string>https://royaltsx-v4.royalapps.com/updates/royaltsx_.+\.dmg</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
-				<string>https://www.royalapplications.com/ts/osx/download</string>
+				<string>https://www.royalapps.com/ts/mac/download</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
Royal Applications moved to using royalapps.com, so the URLTextSesarcher for Royal TSX was failing. Also simplified the `re_pattern` as it relied on specifics of the page design