### PR TITLE
Adding arguments to work around Gitlab

### DIFF
--- a/GitLabArtifact/GitLabArtifact.download.recipe
+++ b/GitLabArtifact/GitLabArtifact.download.recipe
@@ -35,6 +35,37 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>url</key>
+				<string>http://captive.apple.com</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>file_content</key>
+				<string>This is a placeholder file to work GitLab's tendency to return the same etag across multiple URLDownloader runs.</string>
+				<key>file_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.zip</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.zip</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>request_headers</key>


### PR DESCRIPTION
The URLDownload argument is needed so that the recipe creates the downloads folders on the initial run. The following work arounds fail without this in here for the first run.
The FileCreator creates a placeholder to work around GitLab's tendency to return the same etag across multiple URLDownloader runs.
The PathDeleter clears out the old download so that we force a new download from GitLab.