### PR TITLE
Update Proximity.munki.recipe

### DIFF
--- a/Cisco/Proximity.munki.recipe
+++ b/Cisco/Proximity.munki.recipe
@@ -57,6 +57,8 @@
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
Because the CFBundleShortVersionString string starts with a character, it is being ignored per default behavior and the package always thinks it needs an update.