### PR TITLE
Specify that Zscaler is not uninstallable

### DIFF
--- a/Zscaler/Zscaler.munki.recipe
+++ b/Zscaler/Zscaler.munki.recipe
@@ -34,6 +34,8 @@
 			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
+			<key>uninstallable</key>
+			<false/>
 		</dict>
 	</dict>
 	<key>MiniumumVersion</key>


### PR DESCRIPTION
[An uninstall password is required](https://help.zscaler.com/z-app/uninstalling-zscaler-app), and there's no simple way to store that in the Munki repo securely, so marking Zscaler as not uninstallable.