### PR TITLE
Update Waltr.download.recipe

### DIFF
--- a/Waltr/Waltr.download.recipe
+++ b/Waltr/Waltr.download.recipe
@@ -40,7 +40,7 @@
 				<key>input_path</key>
 				<string>%pathname%/Waltr.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.softorino.Waltr" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = M23NK4PKWX)</string>
+				<string>anchor apple generic and identifier "com.softorino.Waltr" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5JVYAEUZ9N")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Updated Code Signature Requirement.

Seems like the dev cert has been updated as "Waltr 2" has rhe same Subject:

anchor apple generic and identifier "com.softorino.waltr2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5JVYAEUZ9N")