### PR TITLE
Removing Extra "version" Key

### DIFF
--- a/TimeMachineEditor/TimeMachineEditor.munki.recipe
+++ b/TimeMachineEditor/TimeMachineEditor.munki.recipe
@@ -28,8 +28,6 @@
 			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
-			<key>version</key>
-			<string>%version%</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
Appears to be a leftover from when TimeMachineEditor was not a downloadable .pkg.  With this extraneous key, a warning "Use of undefined key in variable substitution: u'version'" was printed during recipe execution.