### PR TITLE
Update MerlinProject recipe to support v6

### DIFF
--- a/MerlinProject/MerlinProject.download.recipe
+++ b/MerlinProject/MerlinProject.download.recipe
@@ -51,7 +51,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Merlin Project 5.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Merlin Project 6.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "net.projectwizards.merlinproject" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9R6P9VZV27")</string>
 			</dict>
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Merlin Project 5.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Merlin Project 6.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Merlin is now shipping as v6 and the path has changed. Update the version numbers in the app name so that glob doesn't fail when trying to verify code signature and get the version number.