### PR TITLE
Copier processor uses a different key for over writing than the unarc…

### DIFF
--- a/Tracker/Tracker.pkg.recipe
+++ b/Tracker/Tracker.pkg.recipe
@@ -26,7 +26,7 @@ The Tracker app requires Apple's legacy Java 6 installer. The pkg installer gene
 				<string>%pathname%/Tracker-*-osx-installer.app</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/private/tmp/Tracker-osx-installer.app</string>
-				<key>purge_destination</key>
+				<key>overwrite</key>
 				<true/>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
…hiver processer

Missed this when I swapped in the Copier processor.