### PR TITLE
Updating CodeSignatureVerifier Requirement

### DIFF
--- a/ShirtPocket/SuperDuper.download.recipe
+++ b/ShirtPocket/SuperDuper.download.recipe
@@ -38,7 +38,7 @@
 				<key>input_path</key>
 				<string>%pathname%/SuperDuper!.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.blacey.SuperDuper!" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = A774567WBH)</string>
+				<string>anchor apple generic and identifier "com.blacey.SuperDuper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = A774567WBH)</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
The exclamation point is no longer part of the Identifier with SuperDuper 3.3.