### PR TITLE
Fix copying of Audio plugin and Remove local Zoom user plugins folder

### DIFF
--- a/Zoom/scripts/postinstall
+++ b/Zoom/scripts/postinstall
@@ -186,8 +186,8 @@ function removePluginsInUserFolder
         # Determine home directory of user
         userHome="$(/usr/bin/dscl /Local/Default read /Users/$name NFSHomeDirectory | /usr/bin/awk '{print $2}')"
         
-        if [[ -d "/Users/$userHome/Library/Application Support/zoom.us/Plugins" ]] ; then
-            rm -rf "/Users/$userHome/Library/Application Support/zoom.us/Plugins"
+        if [[ -d "$userHome/Library/Application Support/zoom.us/Plugins" ]] ; then
+            /bin/rm -rf "$userHome/Library/Application Support/zoom.us/Plugins"
         fi
     done
 }

--- a/Zoom/scripts/postinstall
+++ b/Zoom/scripts/postinstall
@@ -42,19 +42,16 @@ audioPluginfile="$app_path/Contents/Plugins/ZoomAudioDevice.driver"
 if [ "$minorver" -gt 9 ]; then
     echo "Install audio device drive" >> "$LOG_PATH"
 
-    # unload device kernel if loaded
-    st="$(/usr/sbin/kextstat -b zoom.us.ZoomAudioDevice | /usr/bin/grep zoom.us.ZoomAudioDevice 2>&1)"
-
-    if echo "$st" | grep -q "zoom.us.ZoomAudioDevice"; then
-        echo "audio device is loaded: ($st) skip driver" >> "$LOG_PATH"
-    else
-        #install audio driver
-        if [ -d "$AudioPluginPath/ZoomAudioDevice.driver" ]; then
-            /bin/rm -rf "$AudioPluginPath/ZoomAudioDevice.driver"
-        fi
-
-        /bin/cp -rf "$audioPluginfile" "$AudioPluginPath"
+    #install audio driver
+    if [ -d "$AudioPluginPath/ZoomAudioDevice.driver" ]; then
+        /bin/rm -rf "$AudioPluginPath/ZoomAudioDevice.driver"
     fi
+
+    # make intermediate directories
+    /bin/mkdir -p "$AudioPluginPath"
+    
+    # copy audio plugin
+    /bin/cp -rf "$audioPluginfile" "$AudioPluginPath"
 #################################
 # use audio device kernel
 else
@@ -181,5 +178,19 @@ else
 fi
 #################################
 #audio device end
+
+function removePluginsInUserFolder
+{
+   # Loop through all users with UIDs over 500
+    for name in $(/usr/bin/dscl /Local/Default list /Users UniqueID | /usr/bin/awk '$2 > 500 {print $1}'); do
+        # Determine home directory of user
+        userHome="$(/usr/bin/dscl /Local/Default read /Users/$name NFSHomeDirectory | /usr/bin/awk '{print $2}')"
+        
+        if [[ -d "/Users/$userHome/Library/Application Support/zoom.us/Plugins" ]] ; then
+            rm -rf "/Users/$userHome/Library/Application Support/zoom.us/Plugins"
+        fi
+    done
+}
+removePluginsInUserFolder
 
 exit 0


### PR DESCRIPTION
Fix 1:
The command cp does not create intermediate directories. This was resulting in an error where the Audio plugin wasn't being copied correctly to path /Library/Audio/Plug-ins/HAL because the directory "HAL" did not exist. In some situations, this would result in the contents of the audio plugin being copied inside the "HAL" directory rather than the "ZoomAudioDevice.driver" plugin being copied. You'd end up with "/Library/Audio/Plug-ins/HAL/Contents/..." which you do not want.
The fix included in this change ensures "HAL" is created beforehand so that when cp runs you end up with "/Library/Audio/Plug-ins/HAL/ZoomAudioDevice.driver"

Note that if the ZoomAudioDevice.driver audio plugin is not installed, when the user tries to share their screen and selects the option "Share computer sound" option, they will be prompted for administrator credentials to install the audio plugin.

Fix 2:
If a user ever runs local Zoom installer, when Zoom is installed in the local user's home directory, a Zoom audio plugin is installed at ~/Library/Application Support/zoom.us/Plugins/ (where ~ is referring to each local user's home directory).

This may create conflicts for Zoom and therefore the plugins folder needs to be deleted. The latest version of the Zoom for IT installer (v4.6.12) includes a function to deal with this scenario. Unsure when it was first introduced by Zoom. The function as implemented in this change has been rewritten to make less assumptions than Zoom's postinstall script so that it cleans up the Zoom plugin folder for all user home directories.

Additional note:
An audio plugin is NOT a kernel extension. For some reason Zoom says they want to unload the Audio plugin using the line: st="$(/usr/sbin/kextstat -b zoom.us.ZoomAudioDevice | /usr/bin/grep zoom.us.ZoomAudioDevice 2>&1)"

This does not actually unload the kext (you'd need to use command kextunload for that) and it also isn't accurate to use for an audio plugin. The check for the "ZoomAudioDevice" has removed to ensure that the Zoom audio plugin always gets installed vs sometimes getting installed.