### PR TITLE
Update sparkle feed url

### DIFF
--- a/Inkscape/Inkscape.pkg.recipe
+++ b/Inkscape/Inkscape.pkg.recipe
@@ -27,6 +27,10 @@
 			<string>AppDmgVersioner</string>
 		</dict>
 		<dict>
+    		<key>Processor</key>
+    		<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>

--- a/VimR/VimR.download.recipe
+++ b/VimR/VimR.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>VimR</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://vimr.org/appcast.xml</string>
+		<string>https://raw.githubusercontent.com/qvacua/vimr/master/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
URL giving 404, updated to the latest feed URL from the VimR.app Info.plist