### PR TITLE
Add version splitter proccessor to fix pkg build naming error

### DIFF
--- a/Inkscape/Inkscape.pkg.recipe
+++ b/Inkscape/Inkscape.pkg.recipe
@@ -28,6 +28,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>
 	</array>


### PR DESCRIPTION
Fixes issue with Inkscape 1.0.0 CFBundleShortVersionString causing AppPkgCreator to fail due to incorrect naming