### PR TITLE
Updating SPARKLE_FEED_URL for BackupLoupe 3

### DIFF
--- a/soma-zone/BackupLoupe.download.recipe
+++ b/soma-zone/BackupLoupe.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>BackupLoupe</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>https://somazonecom.ipage.com/soma-zone.com/BackupLoupe/a/appcast_update.xml</string>
+		<string>https://www.soma-zone.com/BackupLoupe/a/appcast-update-3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
URL changed with the release of BackupLoupe 3.