### PR TITLE
Update Zoom.pkg.recipe

### DIFF
--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/zoom.us.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/expanded/zoomus.pkg/Payload</string>
 			</dict>


### PR DESCRIPTION
Zoom IT installer package has changed to a distribution pkg. When you try to run this recipe now:
`Error in com.github.homebysix.pkg.Zoom: Processor: Versioner: Error: File '/Users/admin/Library/AutoPkg/Cache/com.github.homebysix.pkg.Zoom/Zoom/Applications/zoom.us.app/Contents/Info.plist' does not exist or could not be read.`

This should fix the issue in #333