### PR TITLE
Hazel 5 is now a .app

### DIFF
--- a/Noodlesoft/Hazel.download.recipe
+++ b/Noodlesoft/Hazel.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with some help from Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with some help from Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Hazel.</string>
 	<key>Identifier</key>
@@ -38,9 +38,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Install Hazel.app</string>
+				<string>%pathname%/Hazel.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.noodlesoft.Install-Hazel" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "86Z3GCJ4MF")</string>
+				<string>anchor apple generic and identifier "com.noodlesoft.Hazel" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "86Z3GCJ4MF")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Install Hazel.app/Contents/Resources/Hazel.prefPane/Contents/Info.plist</string>
+				<string>%pathname%/Hazel.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Noodlesoft/Hazel.install.recipe
+++ b/Noodlesoft/Hazel.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with some help from Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with some help from Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Installs the latest version of Hazel.</string>
 	<key>Identifier</key>
@@ -28,9 +28,9 @@
 				<array>
 					<dict>
 						<key>destination_path</key>
-						<string>/Library/PreferencePanes</string>
+						<string>/Applications</string>
 						<key>source_item</key>
-						<string>Install Hazel.app/Contents/Resources/Hazel.prefPane</string>
+						<string>Hazel.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Noodlesoft/Hazel.munki.recipe
+++ b/Noodlesoft/Hazel.munki.recipe
@@ -38,6 +38,21 @@
 	<string>com.github.homebysix.pkg.Hazel</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                	<key>preinstall_script</key>
+                	<string>#!/bin/sh
+
+rm -r /Library/PreferencePanes/Hazel.prefpane
+/usr/sbin/pkgutil --forget com.noodlesoft.Hazel</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Noodlesoft/Hazel.munki.recipe
+++ b/Noodlesoft/Hazel.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with some help from Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with some help from Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Hazel and imports it into Munki.</string>
 	<key>Identifier</key>
@@ -41,6 +41,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Noodlesoft/Hazel.pkg.recipe
+++ b/Noodlesoft/Hazel.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with some help from Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with some help from Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Hazel and creates a package.</string>
 	<key>Identifier</key>
@@ -22,62 +22,8 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Library</key>
-					<string>0775</string>
-					<key>Library/PreferencePanes</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/Library/PreferencePanes/Hazel.prefPane</string>
-				<key>source_path</key>
-				<string>%pathname%/Install Hazel.app/Contents/Resources/Hazel.prefPane</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Library/PreferencePanes</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hazel 5 has been turned into a .app from a Preference Pane. These changes allow the recipes to download and package Hazel 5.

I'm not entirely certain that this shouldn't be a separate set of recipes (named as `Hazel5`, for instance) but I'm trying to fix/improve existing recipes rather than adding more.