### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Google/GoogleChat.pkg.recipe
+++ b/Google/GoogleChat.pkg.recipe
@@ -68,9 +68,9 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>scripts</key>
 					<string>Scripts</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/PublicSpace/VitaminR.pkg.recipe
+++ b/PublicSpace/VitaminR.pkg.recipe
@@ -66,9 +66,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/ShirtPocket/SuperDuper.pkg.recipe
+++ b/ShirtPocket/SuperDuper.pkg.recipe
@@ -68,9 +68,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>SuperDuper-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>SuperDuper-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/Spotify/Spotify.pkg.recipe
+++ b/Spotify/Spotify.pkg.recipe
@@ -84,9 +84,9 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>scripts</key>
 					<string>Scripts</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).