### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/25io/Mou.pkg.recipe
+++ b/25io/Mou.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Mou</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mouapp.Mou</string>
 		<key>NAME</key>
 		<string>Mou</string>
 	</dict>

--- a/25io/Smaller.pkg.recipe
+++ b/25io/Smaller.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Smaller</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.smallerapp.Smaller</string>
 		<key>NAME</key>
 		<string>Smaller</string>
 	</dict>

--- a/ActiveCollab/ActiveCollab.pkg.recipe
+++ b/ActiveCollab/ActiveCollab.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.ActiveCollab</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.activecollab.activecollab-desktop</string>
 		<key>NAME</key>
 		<string>ActiveCollab</string>
 	</dict>

--- a/AirDroid/AirDroid.pkg.recipe
+++ b/AirDroid/AirDroid.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.AirDroid</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.sandstudio.airdroid</string>
 		<key>NAME</key>
 		<string>AirDroid</string>
 	</dict>

--- a/Apache/ApacheDirectoryStudio.pkg.recipe
+++ b/Apache/ApacheDirectoryStudio.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.ApacheDirectoryStudio</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.apache.directory.studio.product</string>
 		<key>NAME</key>
 		<string>ApacheDirectoryStudio</string>
 	</dict>

--- a/AppReviews/AppReviews.pkg.recipe
+++ b/AppReviews/AppReviews.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.AppReviews</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.cocmoc.appreviews</string>
 		<key>NAME</key>
 		<string>App Reviews</string>
 	</dict>

--- a/AppZapper/AppZapper.pkg.recipe
+++ b/AppZapper/AppZapper.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.AppZapper</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.appzapper.AppZapper</string>
 		<key>NAME</key>
 		<string>AppZapper</string>
 	</dict>

--- a/AutoCasperNBI/AutoCasperNBI.pkg.recipe
+++ b/AutoCasperNBI/AutoCasperNBI.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.AutoCasperNBI</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.macmule.AutoCasperNBI</string>
 		<key>NAME</key>
 		<string>AutoCasperNBI</string>
 	</dict>

--- a/AutoPkgr/AutoPkgr.pkg.recipe
+++ b/AutoPkgr/AutoPkgr.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.AutoPkgr</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.lindegroup.AutoPkgr</string>
 		<key>NAME</key>
 		<string>AutoPkgr</string>
 	</dict>

--- a/Automattic/WordPress.com.pkg.recipe
+++ b/Automattic/WordPress.com.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.WordPress.com</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.automattic.wordpress</string>
 		<key>NAME</key>
 		<string>WordPress.com</string>
 	</dict>

--- a/BonjourBrowser/BonjourBrowser.pkg.recipe
+++ b/BonjourBrowser/BonjourBrowser.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.BonjourBrowser</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.tildesoft.RendezvousBrowser</string>
 		<key>NAME</key>
 		<string>BonjourBrowser</string>
 	</dict>

--- a/Bookends/Bookends.pkg.recipe
+++ b/Bookends/Bookends.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Bookends</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.sonnysoftware.bookends</string>
 		<key>NAME</key>
 		<string>Bookends</string>
 	</dict>

--- a/Boom/Boom2.pkg.recipe
+++ b/Boom/Boom2.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Boom2</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.globaldelight.Boom2</string>
 		<key>NAME</key>
 		<string>Boom 2</string>
 	</dict>

--- a/Brent Simmons/NetNewsWire.pkg.recipe
+++ b/Brent Simmons/NetNewsWire.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.NetNewsWire</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.ranchero.NetNewsWire-Evergreen</string>
 		<key>NAME</key>
 		<string>NetNewsWire</string>
 	</dict>

--- a/C-Command/EagleFiler.pkg.recipe
+++ b/C-Command/EagleFiler.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.EagleFiler</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.c-command.EagleFiler</string>
 		<key>NAME</key>
 		<string>EagleFiler</string>
 	</dict>

--- a/C-Command/SpamSieve.pkg.recipe
+++ b/C-Command/SpamSieve.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.SpamSieve</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.c-command.SpamSieve</string>
 		<key>NAME</key>
 		<string>SpamSieve</string>
 	</dict>

--- a/CCleaner/CCleaner.pkg.recipe
+++ b/CCleaner/CCleaner.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.CCleaner</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.piriform.ccleaner</string>
 		<key>NAME</key>
 		<string>CCleaner</string>
 	</dict>

--- a/Caffeine/Caffeine.pkg.recipe
+++ b/Caffeine/Caffeine.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Caffeine</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.lightheadsw.Caffeine</string>
 		<key>NAME</key>
 		<string>Caffeine</string>
 	</dict>

--- a/CaseApps/SofaControl.pkg.recipe
+++ b/CaseApps/SofaControl.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.SofaControl</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.gravityapps.SofaControl</string>
 		<key>NAME</key>
 		<string>Sofa Control</string>
 	</dict>

--- a/CaseApps/Tags.pkg.recipe
+++ b/CaseApps/Tags.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Tags</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.gravityapps.Tags</string>
 		<key>NAME</key>
 		<string>Tags</string>
 	</dict>

--- a/ChronoSync/ChronoAgent.pkg.recipe
+++ b/ChronoSync/ChronoAgent.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.ChronoAgent</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.econtechnologies.chronosync</string>
 		<key>NAME</key>
 		<string>ChronoAgent</string>
 	</dict>

--- a/ChronoSync/ChronoSync.pkg.recipe
+++ b/ChronoSync/ChronoSync.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.ChronoSync</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.econtechnologies.chronosync</string>
 		<key>NAME</key>
 		<string>ChronoSync</string>
 	</dict>

--- a/Cisco/Proximity.pkg.recipe
+++ b/Cisco/Proximity.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Proximity</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.cisco.experimental.Proximity</string>
 		<key>NAME</key>
 		<string>Cisco Proximity</string>
 	</dict>

--- a/Cisdem/BetterUnarchiver.pkg.recipe
+++ b/Cisdem/BetterUnarchiver.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.BetterUnarchiver</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.enolsoft.powerunarchiver</string>
 		<key>NAME</key>
 		<string>Cisdem BetterUnarchiver</string>
 	</dict>

--- a/Cockos/licecap.pkg.recipe
+++ b/Cockos/licecap.pkg.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>LICEcap</string>
-		<key>BUNDLE_ID</key>
-		<string>com.cockos.LICEcap</string>
 		<key>NAME</key>
 		<string>licecap</string>
 	</dict>

--- a/Cocktail/Cocktail-10.14.pkg.recipe
+++ b/Cocktail/Cocktail-10.14.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Cocktail-10.14</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.mojave</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>

--- a/Cocktail/Cocktail-10.15.pkg.recipe
+++ b/Cocktail/Cocktail-10.15.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Cocktail-10.15</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.catalina</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>

--- a/Cocktail/CocktailBigSur.pkg.recipe
+++ b/Cocktail/CocktailBigSur.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.CocktailBigSur</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.catalina</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>

--- a/CocoaRestClient/CocoaRestClient.pkg.recipe
+++ b/CocoaRestClient/CocoaRestClient.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.CocoaRestClient</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.restlesscode.cocoarestclient</string>
 		<key>NAME</key>
 		<string>CocoaRestClient</string>
 	</dict>

--- a/ColorSnapper/ColorSnapper.pkg.recipe
+++ b/ColorSnapper/ColorSnapper.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.ColorSnapper</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.koolesache.ColorSnapper2</string>
 		<key>NAME</key>
 		<string>ColorSnapper2</string>
 	</dict>

--- a/Contexts/Contexts.pkg.recipe
+++ b/Contexts/Contexts.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Contexts</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.contextsformac.Contexts</string>
 		<key>NAME</key>
 		<string>Contexts</string>
 	</dict>

--- a/Deltopia/DeltaWalker.pkg.recipe
+++ b/Deltopia/DeltaWalker.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.DeltaWalker</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.deltopia.DeltaWalker</string>
 		<key>NAME</key>
 		<string>DeltaWalker</string>
 	</dict>

--- a/Docker/DockerToolbox.pkg.recipe
+++ b/Docker/DockerToolbox.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.DockerToolbox</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>io.docker.pkg.docker</string>
 		<key>NAME</key>
 		<string>DockerToolbox</string>
 		<key>pathname</key>

--- a/Docker/Kitematic.pkg.recipe
+++ b/Docker/Kitematic.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.jps3.pkg.Kitematic</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.electron.kitematic</string>
 		<key>NAME</key>
 		<string>Kitematic</string>
 	</dict>

--- a/Dozer/Dozer.pkg.recipe
+++ b/Dozer/Dozer.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Dozer</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mortennn.Dozer</string>
 		<key>NAME</key>
 		<string>Dozer</string>
 	</dict>

--- a/Elliot Jordan/Recipe Robot.pkg.recipe
+++ b/Elliot Jordan/Recipe Robot.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.RecipeRobot</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.elliotjordan.recipe-robot</string>
 		<key>NAME</key>
 		<string>Recipe Robot</string>
 	</dict>

--- a/Emailchemy/Emailchemy.pkg.recipe
+++ b/Emailchemy/Emailchemy.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Emailchemy</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.install4j.6029-5726-8846-0121.89</string>
 		<key>NAME</key>
 		<string>Emailchemy</string>
 	</dict>

--- a/Flinto/Flinto.pkg.recipe
+++ b/Flinto/Flinto.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Flinto</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.flinto.Flinto</string>
 		<key>NAME</key>
 		<string>Flinto</string>
 	</dict>

--- a/FoldingText/FoldingText.pkg.recipe
+++ b/FoldingText/FoldingText.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.FoldingText</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.foldingtext.paddle.FoldingText</string>
 		<key>NAME</key>
 		<string>FoldingText</string>
 	</dict>

--- a/GB Studio/GB Studio.pkg.recipe
+++ b/GB Studio/GB Studio.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.GBStudio</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.electron.gb-studio</string>
 		<key>NAME</key>
 		<string>GB Studio</string>
 	</dict>

--- a/GitHub/GitHubCLI.pkg.recipe
+++ b/GitHub/GitHubCLI.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.GitHubCLI</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.github.GitHub</string>
 		<key>NAME</key>
 		<string>GitHub CLI</string>
 	</dict>
@@ -59,10 +57,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unzipped/*/bin/gh</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/usr/local/bin/gh</string>
+				<key>source_path</key>
+				<string>%RECIPE_CACHE_DIR%/unzipped/*/bin/gh</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -70,12 +68,12 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unzipped/*/share/man/man1</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/usr/local/share/man/man1</string>
 				<key>overwrite</key>
 				<true/>
+				<key>source_path</key>
+				<string>%RECIPE_CACHE_DIR%/unzipped/*/share/man/man1</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Grammarly/Grammarly.pkg.recipe
+++ b/Grammarly/Grammarly.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Grammarly</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.grammarly.DesktopEditor</string>
 		<key>NAME</key>
 		<string>Grammarly</string>
 	</dict>

--- a/GrandPerspective/GrandPerspective.pkg.recipe
+++ b/GrandPerspective/GrandPerspective.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.GrandPerspective</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.sourceforge.grandperspectiv</string>
 		<key>NAME</key>
 		<string>GrandPerspective</string>
 	</dict>

--- a/HazeOver/HazeOver.pkg.recipe
+++ b/HazeOver/HazeOver.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.HazeOver</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.pointum.hazeover</string>
 		<key>NAME</key>
 		<string>HazeOver</string>
 	</dict>

--- a/Karelia/TheHitList.pkg.recipe
+++ b/Karelia/TheHitList.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.TheHitList</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.potionfactory.TheHitList</string>
 		<key>NAME</key>
 		<string>The Hit List</string>
 	</dict>

--- a/KeePassX/KeePassX.pkg.recipe
+++ b/KeePassX/KeePassX.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.KeePassX</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.keepassx.keepassx</string>
 		<key>NAME</key>
 		<string>KeePassX</string>
 	</dict>

--- a/Kite/Kite.pkg.recipe
+++ b/Kite/Kite.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Kite</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kite.Kite</string>
 		<key>NAME</key>
 		<string>Kite</string>
 	</dict>

--- a/MacPaw/Gemini2.pkg.recipe
+++ b/MacPaw/Gemini2.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Gemini2</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.macpaw.site.Gemini2</string>
 		<key>NAME</key>
 		<string>Gemini 2</string>
 	</dict>

--- a/MacTerm/MacTerm.pkg.recipe
+++ b/MacTerm/MacTerm.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.MacTerm</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.macterm.MacTerm</string>
 		<key>NAME</key>
 		<string>MacTerm</string>
 	</dict>

--- a/Macroplant/Adapter.pkg.recipe
+++ b/Macroplant/Adapter.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Adapter</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.macroplant.adapter</string>
 		<key>NAME</key>
 		<string>Adapter</string>
 	</dict>

--- a/Malwarebytes/Malwarebytes.pkg.recipe
+++ b/Malwarebytes/Malwarebytes.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Malwarebytes</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.malwarebytes.antimalware</string>
 		<key>NAME</key>
 		<string>Malwarebytes</string>
 	</dict>

--- a/ManyTricks/Butler.pkg.recipe
+++ b/ManyTricks/Butler.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Butler</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Butler</string>
 		<key>NAME</key>
 		<string>Butler</string>
 	</dict>

--- a/ManyTricks/DesktopCurtain.pkg.recipe
+++ b/ManyTricks/DesktopCurtain.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.DesktopCurtain</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.DesktopCurtain</string>
 		<key>NAME</key>
 		<string>Desktop Curtain</string>
 	</dict>

--- a/ManyTricks/Displaperture.pkg.recipe
+++ b/ManyTricks/Displaperture.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Displaperture</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Displaperture</string>
 		<key>NAME</key>
 		<string>Displaperture</string>
 	</dict>

--- a/ManyTricks/KeyCodes.pkg.recipe
+++ b/ManyTricks/KeyCodes.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.KeyCodes</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.KeyCodes</string>
 		<key>NAME</key>
 		<string>Key Codes</string>
 	</dict>

--- a/ManyTricks/Keymou.pkg.recipe
+++ b/ManyTricks/Keymou.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Keymo</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Keymo</string>
 		<key>NAME</key>
 		<string>Keymou</string>
 	</dict>

--- a/ManyTricks/Leech.pkg.recipe
+++ b/ManyTricks/Leech.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Leech</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Leech</string>
 		<key>NAME</key>
 		<string>Leech</string>
 	</dict>

--- a/ManyTricks/Moom.pkg.recipe
+++ b/ManyTricks/Moom.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Moom</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Moom</string>
 		<key>NAME</key>
 		<string>Moom</string>
 	</dict>

--- a/ManyTricks/NameMangler.pkg.recipe
+++ b/ManyTricks/NameMangler.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.NameMangler</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.NameMangler</string>
 		<key>NAME</key>
 		<string>Name Mangler</string>
 	</dict>

--- a/ManyTricks/OpenWithManager.pkg.recipe
+++ b/ManyTricks/OpenWithManager.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.OpenWithManager</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Open-With Manager</string>
 		<key>NAME</key>
 		<string>Open-With Manager</string>
 	</dict>

--- a/ManyTricks/Resolutionator.pkg.recipe
+++ b/ManyTricks/Resolutionator.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Resolutionator</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Resolutionator</string>
 		<key>NAME</key>
 		<string>Resolutionator</string>
 	</dict>

--- a/ManyTricks/TimeSink.pkg.recipe
+++ b/ManyTricks/TimeSink.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.TimeSink</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.TimeSinkClient</string>
 		<key>NAME</key>
 		<string>Time Sink</string>
 	</dict>

--- a/ManyTricks/Usher.pkg.recipe
+++ b/ManyTricks/Usher.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Usher</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manytricks.Usher</string>
 		<key>NAME</key>
 		<string>Usher</string>
 	</dict>

--- a/Mellel/Mellel.pkg.recipe
+++ b/Mellel/Mellel.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Mellel</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.redlex.mellel</string>
 		<key>NAME</key>
 		<string>Mellel</string>
 	</dict>

--- a/MyMixApps/FilePane.pkg.recipe
+++ b/MyMixApps/FilePane.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.FilePane</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mymixapps.FilePane</string>
 		<key>NAME</key>
 		<string>FilePane</string>
 	</dict>

--- a/NetSurf/NetSurf.pkg.recipe
+++ b/NetSurf/NetSurf.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.NetSurf</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.netsurf-browser.NetSurf</string>
 		<key>NAME</key>
 		<string>NetSurf</string>
 	</dict>

--- a/NightOwl/NightOwl.pkg.recipe
+++ b/NightOwl/NightOwl.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.NightOwl</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.fuekiin.NightOwl</string>
 		<key>NAME</key>
 		<string>NightOwl</string>
 	</dict>

--- a/ObjectiveDevelopment/LaunchBar.pkg.recipe
+++ b/ObjectiveDevelopment/LaunchBar.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.LaunchBar</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>at.obdev.LaunchBar</string>
 		<key>NAME</key>
 		<string>LaunchBar</string>
 	</dict>

--- a/Open in Atom/Open in Atom.pkg.recipe
+++ b/Open in Atom/Open in Atom.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.OpeninAtomforFinder</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>cdz.finder-atom-integration</string>
 		<key>NAME</key>
 		<string>Open in Atom</string>
 	</dict>

--- a/PDFKit/PDFKit.pkg.recipe
+++ b/PDFKit/PDFKit.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.PDFKit</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.ireador.PDFKit</string>
 		<key>NAME</key>
 		<string>PDFKit</string>
 	</dict>

--- a/Pandora/Pandora.pkg.recipe
+++ b/Pandora/Pandora.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Pandora</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.pandora.desktop</string>
 		<key>NAME</key>
 		<string>Pandora</string>
 	</dict>

--- a/Papers/Papers.pkg.recipe
+++ b/Papers/Papers.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Papers</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mekentosj.papers3</string>
 		<key>NAME</key>
 		<string>Papers</string>
 	</dict>

--- a/Pingendo/Pingendo.pkg.recipe
+++ b/Pingendo/Pingendo.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Pingendo</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.pingendo.editor</string>
 		<key>NAME</key>
 		<string>Pingendo</string>
 	</dict>

--- a/Plug/Plug.pkg.recipe
+++ b/Plug/Plug.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Plug</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.plug.Plug2</string>
 		<key>NAME</key>
 		<string>Plug</string>
 	</dict>

--- a/Postbox/Postbox.pkg.recipe
+++ b/Postbox/Postbox.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Postbox</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.postbox-inc.postbox</string>
 		<key>NAME</key>
 		<string>Postbox</string>
 	</dict>

--- a/Quip/Quip.pkg.recipe
+++ b/Quip/Quip.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Quip</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.quip.Desktop</string>
 		<key>NAME</key>
 		<string>Quip</string>
 	</dict>

--- a/Reinvented/Feeder3.pkg.recipe
+++ b/Reinvented/Feeder3.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Feeder3</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.reinvented.Feeder3</string>
 		<key>NAME</key>
 		<string>Feeder 3</string>
 	</dict>

--- a/Reinvented/Feeder4.pkg.recipe
+++ b/Reinvented/Feeder4.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Feeder4</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.reinvented.Feeder4</string>
 		<key>NAME</key>
 		<string>Feeder 4</string>
 	</dict>

--- a/Reinvented/Together.pkg.recipe
+++ b/Reinvented/Together.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Together3</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.reinvented.Together3</string>
 		<key>NAME</key>
 		<string>Together 3</string>
 	</dict>

--- a/Revisions/Revisions.pkg.recipe
+++ b/Revisions/Revisions.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.Revisions</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.bayesbits.Revisions</string>
 		<key>NAME</key>
 		<string>Revisions</string>
 	</dict>

--- a/Royal/RoyalTSX.pkg.recipe
+++ b/Royal/RoyalTSX.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.RoyalTSX</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.lemonmojo.RoyalTSX.App</string>
 		<key>NAME</key>
 		<string>Royal TSX</string>
 	</dict>

--- a/Sblack/Sblack.pkg.recipe
+++ b/Sblack/Sblack.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Sblack</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>co.boxyapp.slack</string>
 		<key>NAME</key>
 		<string>Sblack</string>
 	</dict>

--- a/Scherlokk/Scherlokk.pkg.recipe
+++ b/Scherlokk/Scherlokk.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Scherlokk</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.naarak.Scherlokk</string>
 		<key>NAME</key>
 		<string>Scherlokk</string>
 	</dict>

--- a/ShareMouse/ShareMouse.pkg.recipe
+++ b/ShareMouse/ShareMouse.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.ShareMouse</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.bartelsmedia.ShareMouse</string>
 		<key>NAME</key>
 		<string>ShareMouse</string>
 	</dict>

--- a/Skim/Skim.pkg.recipe
+++ b/Skim/Skim.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Skim</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.sourceforge.skim-app.skim</string>
 		<key>NAME</key>
 		<string>Skim</string>
 	</dict>

--- a/SnapGene/SnapGeneViewer.pkg.recipe
+++ b/SnapGene/SnapGeneViewer.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.SnapGeneViewer</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.gslbiotech.snapgeneviewer</string>
 		<key>NAME</key>
 		<string>SnapGene Viewer</string>
 	</dict>

--- a/SpiderOak/SpiderOakONE.pkg.recipe
+++ b/SpiderOak/SpiderOakONE.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.SpiderOakONE</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.spideroak.orange.client</string>
 		<key>NAME</key>
 		<string>SpiderOakONE</string>
 		<key>pkg_path</key>

--- a/Sublime HQ/Sublime Merge.pkg.recipe
+++ b/Sublime HQ/Sublime Merge.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.SublimeMerge</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.sublimemerge</string>
 		<key>NAME</key>
 		<string>Sublime Merge</string>
 	</dict>

--- a/SugarSync/SugarSync.pkg.recipe
+++ b/SugarSync/SugarSync.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.SugarSync</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.SugarSync.SugarSync</string>
 		<key>NAME</key>
 		<string>SugarSync</string>
 	</dict>

--- a/SuperMegaUltraGroovy/FuzzMeasure.pkg.recipe
+++ b/SuperMegaUltraGroovy/FuzzMeasure.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.FuzzMeasure</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.supermegaultragroovy.fuzzmeasure4.mac</string>
 		<key>NAME</key>
 		<string>FuzzMeasure</string>
 	</dict>

--- a/TMNotifier/TMNotifier.pkg.recipe
+++ b/TMNotifier/TMNotifier.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.TMNotifier</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.everythingisgray.TMNotifier</string>
 		<key>NAME</key>
 		<string>TMNotifier</string>
 	</dict>

--- a/TermHere/TermHere.pkg.recipe
+++ b/TermHere/TermHere.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.TermHere</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>ws.hbang.TermHere</string>
 		<key>NAME</key>
 		<string>TermHere</string>
 	</dict>

--- a/Thyme/Thyme.pkg.recipe
+++ b/Thyme/Thyme.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Thyme</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.joaomoreno.Thyme</string>
 		<key>NAME</key>
 		<string>Thyme</string>
 	</dict>

--- a/Toggl/TogglDesktop.pkg.recipe
+++ b/Toggl/TogglDesktop.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.TogglDesktop</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.toggl.toggldesktop.TogglDesktop</string>
 		<key>NAME</key>
 		<string>TogglDesktop</string>
 	</dict>

--- a/TouchSwitcher/TouchSwitcher.pkg.recipe
+++ b/TouchSwitcher/TouchSwitcher.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.TouchSwitcher</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.pointum.TouchSwitcher</string>
 		<key>NAME</key>
 		<string>TouchSwitcher</string>
 	</dict>

--- a/Tunabelly/DiskDiet.pkg.recipe
+++ b/Tunabelly/DiskDiet.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.DiskDiet</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.tunabellysoftware.diskdiet</string>
 		<key>NAME</key>
 		<string>Disk Diet</string>
 	</dict>

--- a/Vadim Shpakovski/NativeConnect.pkg.recipe
+++ b/Vadim Shpakovski/NativeConnect.pkg.recipe
@@ -10,13 +10,11 @@
 	<string>com.github.homebysix.pkg.NativeConnect</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.shpakovski.NativeConnect</string>
 		<key>NAME</key>
 		<string>NativeConnect</string>
 	</dict>
 	<key>MinimumVersion</key>
-    <string>1.4</string>
+	<string>1.4</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.NativeConnect</string>
 	<key>Process</key>

--- a/Vanilla/Vanilla.pkg.recipe
+++ b/Vanilla/Vanilla.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Vanilla</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.matthewpalmer.Vanilla</string>
 		<key>NAME</key>
 		<string>Vanilla</string>
 	</dict>

--- a/VyprVPN/VyprVPN.pkg.recipe
+++ b/VyprVPN/VyprVPN.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.pkg.VyprVPN</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.goldenfrog.VyprVPN</string>
 		<key>NAME</key>
 		<string>VyprVPN</string>
 	</dict>

--- a/Waltr/Waltr.pkg.recipe
+++ b/Waltr/Waltr.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Waltr</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.softorino.Waltr</string>
 		<key>NAME</key>
 		<string>Waltr</string>
 	</dict>

--- a/Warewolf/Espresso.pkg.recipe
+++ b/Warewolf/Espresso.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.Espresso</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>co.warewolf.Espresso</string>
 		<key>NAME</key>
 		<string>Espresso</string>
 	</dict>

--- a/WhatSize/WhatSize.pkg.recipe
+++ b/WhatSize/WhatSize.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.WhatSize</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.id-design.whatsize</string>
 		<key>NAME</key>
 		<string>WhatSize</string>
 	</dict>

--- a/YellowMug/EasyBatchPhoto.pkg.recipe
+++ b/YellowMug/EasyBatchPhoto.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.EasyBatchPhoto</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.yellowmug.EasyBatchPhoto</string>
 		<key>NAME</key>
 		<string>EasyBatchPhoto</string>
 	</dict>

--- a/YellowMug/YemuZip.pkg.recipe
+++ b/YellowMug/YemuZip.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.YemuZip</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.yellowmug.YemuZip</string>
 		<key>NAME</key>
 		<string>YemuZip</string>
 	</dict>

--- a/coconutBattery/coconutBattery.pkg.recipe
+++ b/coconutBattery/coconutBattery.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.coconutBattery</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.coconut-flavour.coconutBattery</string>
 		<key>NAME</key>
 		<string>coconutBattery</string>
 	</dict>

--- a/iStumbler/iStumbler.pkg.recipe
+++ b/iStumbler/iStumbler.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.iStumbler</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.istumbler</string>
 		<key>NAME</key>
 		<string>iStumbler</string>
 	</dict>

--- a/iZip/iZip.pkg.recipe
+++ b/iZip/iZip.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.iZip</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.iboostup.izip</string>
 		<key>NAME</key>
 		<string>iZip</string>
 	</dict>

--- a/miXscope/miXscope.pkg.recipe
+++ b/miXscope/miXscope.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.homebysix.pkg.miXscope</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.edhsw.miXscope</string>
 		<key>NAME</key>
 		<string>miXscope</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ 25io/Mou.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/25io/Mou.pkg.recipe
Processing repos/homebysix-recipes/25io/Mou.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'http://mouapp.com/up/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 870
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 0.8.7
SparkleUpdateInfoProvider: Found URL http://25.io/mou/download/Mou.zip
{'Output': {'url': 'http://25.io/mou/download/Mou.zip', 'version': '0.8.7'}}
URLDownloader
{'Input': {'filename': 'Mou-0.8.7.zip',
           'url': 'http://25.io/mou/download/Mou.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Mou/downloads/Mou-0.8.7.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Mou/downloads/Mou-0.8.7.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Mou/receipts/Mou.pkg-receipt-20210213-205347.plist

Nothing downloaded, packaged or imported.
```

## ✅ 25io/Smaller.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/25io/Smaller.pkg.recipe
Processing repos/homebysix-recipes/25io/Smaller.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'http://25.io/smaller/up/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1400
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.4
SparkleUpdateInfoProvider: Found URL http://25.io/smaller/download/Smaller.zip
{'Output': {'url': 'http://25.io/smaller/download/Smaller.zip',
            'version': '1.4'}}
URLDownloader
{'Input': {'filename': 'Smaller-1.4.zip',
           'url': 'http://25.io/smaller/download/Smaller.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Smaller/downloads/Smaller-1.4.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Smaller/downloads/Smaller-1.4.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Smaller/receipts/Smaller.pkg-receipt-20210213-205348.plist

Nothing downloaded, packaged or imported.
```

## ✅ ActiveCollab/ActiveCollab.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ActiveCollab/ActiveCollab.pkg.recipe
Processing repos/homebysix-recipes/ActiveCollab/ActiveCollab.pkg.recipe...
URLDownloader
{'Input': {'filename': 'ActiveCollab.dmg',
           'url': 'https://accounts.activecollab.com/api/v2/desktop-apps/activecollab/releases/darwin/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: File size returned by webserver matches that of the cached file: 77141634 bytes
URLDownloader: WARNING: Matching a download by filesize is a fallback mechanism that does not guarantee that a build is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ActiveCollab/downloads/ActiveCollab.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ActiveCollab/downloads/ActiveCollab.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ActiveCollab/receipts/ActiveCollab.pkg-receipt-20210213-205416.plist

Nothing downloaded, packaged or imported.
```

## ✅ AirDroid/AirDroid.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/AirDroid/AirDroid.pkg.recipe
Processing repos/homebysix-recipes/AirDroid/AirDroid.pkg.recipe...
URLDownloader
{'Input': {'filename': 'AirDroid.dmg',
           'url': 'https://srv3.airdroid.com/p20/web/getbinaryredirect?type=dmg&channel=&version='}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AirDroid/downloads/AirDroid.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AirDroid/downloads/AirDroid.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AirDroid/receipts/AirDroid.pkg-receipt-20210213-205417.plist

Nothing downloaded, packaged or imported.
```

## ✅ Apache/ApacheDirectoryStudio.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Apache/ApacheDirectoryStudio.pkg.recipe
Processing repos/homebysix-recipes/Apache/ApacheDirectoryStudio.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '<a href="([\\d]+\\..+)/">',
           'result_output_var_name': 'version',
           'url': 'https://dist.apache.org/repos/dist/release/directory/studio/'}}
URLTextSearcher: Found matching text (version): 2.0.0.v20200411-M15
{'Output': {'version': '2.0.0.v20200411-M15'}}
URLDownloader
{'Input': {'url': 'https://dist.apache.org/repos/dist/release/directory/studio/2.0.0.v20200411-M15/ApacheDirectoryStudio-2.0.0.v20200411-M15-macosx.cocoa.x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ApacheDirectoryStudio/downloads/ApacheDirectoryStudio-2.0.0.v20200411-M15-macosx.cocoa.x86_64.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ApacheDirectoryStudio/downloads/ApacheDirectoryStudio-2.0.0.v20200411-M15-macosx.cocoa.x86_64.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ApacheDirectoryStudio/receipts/ApacheDirectoryStudio.pkg-receipt-20210213-205418.plist

Nothing downloaded, packaged or imported.
```

## ✅ AppReviews/AppReviews.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/AppReviews/AppReviews.pkg.recipe
Processing repos/homebysix-recipes/AppReviews/AppReviews.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'knutigro/AppReviews'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'App_Reviews.zip' from release '0.0.32'
{'Output': {'release_notes': '- New Icon\n'
                             '- It is now possible to resize review window\n'
                             '- Bug when resizing review cells fixed.\n'
                             '- Shortcut keys for easier navigation.\n',
            'url': 'https://github.com/knutigro/AppReviews/releases/download/0.0.32/App_Reviews.zip',
            'version': '0.0.32'}}
URLDownloader
{'Input': {'filename': 'App Reviews-0.0.32.zip',
           'url': 'https://github.com/knutigro/AppReviews/releases/download/0.0.32/App_Reviews.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AppReviews/downloads/App Reviews-0.0.32.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AppReviews/downloads/App '
                        'Reviews-0.0.32.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AppReviews/receipts/AppReviews.pkg-receipt-20210213-205419.plist

Nothing downloaded, packaged or imported.
```

## ✅ AppZapper/AppZapper.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/AppZapper/AppZapper.pkg.recipe
Processing repos/homebysix-recipes/AppZapper/AppZapper.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.appzapper.com/az2appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.0.1
SparkleUpdateInfoProvider: Found URL http://www.appzapper.com/downloads/AppZapper2.0.1.zip
{'Output': {'url': 'http://www.appzapper.com/downloads/AppZapper2.0.1.zip',
            'version': '2.0.1'}}
URLDownloader
{'Input': {'filename': 'AppZapper-2.0.1.zip',
           'url': 'http://www.appzapper.com/downloads/AppZapper2.0.1.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AppZapper/downloads/AppZapper-2.0.1.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AppZapper/downloads/AppZapper-2.0.1.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AppZapper/receipts/AppZapper.pkg-receipt-20210213-205421.plist

Nothing downloaded, packaged or imported.
```

## ✅ AutoCasperNBI/AutoCasperNBI.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/AutoCasperNBI/AutoCasperNBI.pkg.recipe
Processing repos/homebysix-recipes/AutoCasperNBI/AutoCasperNBI.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'macmule/AutoCasperNBI'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'AutoCasperNBI.zip' from release 'AutoCasperNBI 1.5.2'
{'Output': {'release_notes': '## Notarized!\r\n'
                             '\r\n'
                             'As per the forthcoming changes mentioned at: '
                             'https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution\r\n'
                             '\r\n'
                             '## Updates/Changes\r\n'
                             '• Updated project settings to recommended\r\n'
                             '• Updated Sparkle to 1.21.3\r\n'
                             '• Added/Amended items required to enable '
                             'notarization',
            'url': 'https://github.com/macmule/AutoCasperNBI/releases/download/1.5.2/AutoCasperNBI.zip',
            'version': '1.5.2'}}
URLDownloader
{'Input': {'filename': 'AutoCasperNBI-1.5.2.zip',
           'url': 'https://github.com/macmule/AutoCasperNBI/releases/download/1.5.2/AutoCasperNBI.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AutoCasperNBI/downloads/AutoCasperNBI-1.5.2.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AutoCasperNBI/downloads/AutoCasperNBI-1.5.2.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AutoCasperNBI/receipts/AutoCasperNBI.pkg-receipt-20210213-205422.plist

Nothing downloaded, packaged or imported.
```

## ✅ AutoPkgr/AutoPkgr.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/AutoPkgr/AutoPkgr.pkg.recipe
Processing repos/homebysix-recipes/AutoPkgr/AutoPkgr.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/lindegroup/autopkgr/appcast/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1475
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.5.5
SparkleUpdateInfoProvider: Found URL https://github.com/lindegroup/autopkgr/releases/download/v1.5.5/AutoPkgr-1.5.5.dmg
{'Output': {'url': 'https://github.com/lindegroup/autopkgr/releases/download/v1.5.5/AutoPkgr-1.5.5.dmg',
            'version': '1.5.5'}}
URLDownloader
{'Input': {'filename': 'AutoPkgr-1.5.5.dmg',
           'url': 'https://github.com/lindegroup/autopkgr/releases/download/v1.5.5/AutoPkgr-1.5.5.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AutoPkgr/downloads/AutoPkgr-1.5.5.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AutoPkgr/downloads/AutoPkgr-1.5.5.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.AutoPkgr/receipts/AutoPkgr.pkg-receipt-20210213-205423.plist

Nothing downloaded, packaged or imported.
```

## ✅ Automattic/WordPress.com.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Automattic/WordPress.com.pkg.recipe
Processing repos/homebysix-recipes/Automattic/WordPress.com.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(rest/v[\\d\\.]+/desktop/osx/download\\?type=dmg)',
           'result_output_var_name': 'download_path',
           'url': 'https://apps.wordpress.com/d/osx/'}}
URLTextSearcher: Found matching text (download_path): rest/v1.1/desktop/osx/download?type=dmg
{'Output': {'download_path': 'rest/v1.1/desktop/osx/download?type=dmg'}}
URLDownloader
{'Input': {'filename': 'WordPress.com.dmg',
           'url': 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.WordPress.com/downloads/WordPress.com.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.WordPress.com/downloads/WordPress.com.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.WordPress.com/receipts/WordPress.com.pkg-receipt-20210213-205424.plist

Nothing downloaded, packaged or imported.
```

## ✅ BonjourBrowser/BonjourBrowser.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/BonjourBrowser/BonjourBrowser.pkg.recipe
Processing repos/homebysix-recipes/BonjourBrowser/BonjourBrowser.pkg.recipe...
URLDownloader
{'Input': {'filename': 'BonjourBrowser.dmg',
           'url': 'http://www.tildesoft.com/files/BonjourBrowser.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.BonjourBrowser/downloads/BonjourBrowser.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.BonjourBrowser/downloads/BonjourBrowser.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.BonjourBrowser/receipts/BonjourBrowser.pkg-receipt-20210213-205426.plist

Nothing downloaded, packaged or imported.
```

## ✅ Bookends/Bookends.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Bookends/Bookends.pkg.recipe
Processing repos/homebysix-recipes/Bookends/Bookends.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Bookends.dmg',
           'url': 'https://www.sonnysoftware.com/Bookends.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Bookends/downloads/Bookends.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Bookends/downloads/Bookends.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Bookends/receipts/Bookends.pkg-receipt-20210213-205427.plist

Nothing downloaded, packaged or imported.
```

## ✅ Boom/Boom2.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Boom/Boom2.pkg.recipe
Processing repos/homebysix-recipes/Boom/Boom2.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Boom 2.dmg',
           'url': 'https://www.globaldelight.com/boom/download/2x/web/boom2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Boom2/downloads/Boom 2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Boom2/downloads/Boom '
                        '2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Boom2/receipts/Boom2.pkg-receipt-20210213-205428.plist

Nothing downloaded, packaged or imported.
```

## ✅ Brent Simmons/NetNewsWire.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Brent\ Simmons/NetNewsWire.pkg.recipe
Processing repos/homebysix-recipes/Brent Simmons/NetNewsWire.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://ranchero.com/downloads/netnewswire-release.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3018
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 5.1.3
SparkleUpdateInfoProvider: Found URL https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-5.1.3/NetNewsWire5.1.3.zip
{'Output': {'url': 'https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-5.1.3/NetNewsWire5.1.3.zip',
            'version': '5.1.3'}}
URLDownloader
{'Input': {'filename': 'NetNewsWire-5.1.3.zip',
           'url': 'https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-5.1.3/NetNewsWire5.1.3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NetNewsWire/downloads/NetNewsWire-5.1.3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NetNewsWire/downloads/NetNewsWire-5.1.3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NetNewsWire/receipts/NetNewsWire.pkg-receipt-20210213-205429.plist

Nothing downloaded, packaged or imported.
```

## ✅ C-Command/EagleFiler.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/C-Command/EagleFiler.pkg.recipe
Processing repos/homebysix-recipes/C-Command/EagleFiler.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '/downloads/EagleFiler-([\\d\\.]+).dmg',
           'result_output_var_name': 'version',
           'url': 'https://c-command.com/eaglefiler/'}}
URLTextSearcher: Found matching text (version): 1.9.2
{'Output': {'version': '1.9.2'}}
URLDownloader
{'Input': {'filename': 'EagleFiler-1.9.2.dmg',
           'url': 'https://c-command.com/downloads/EagleFiler-1.9.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.EagleFiler/downloads/EagleFiler-1.9.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.EagleFiler/downloads/EagleFiler-1.9.2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.EagleFiler/receipts/EagleFiler.pkg-receipt-20210213-205431.plist

Nothing downloaded, packaged or imported.
```

## ✅ C-Command/SpamSieve.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/C-Command/SpamSieve.pkg.recipe
Processing repos/homebysix-recipes/C-Command/SpamSieve.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '/downloads/SpamSieve-([\\d\\.]+).dmg',
           'result_output_var_name': 'version',
           'url': 'https://c-command.com/spamsieve/'}}
URLTextSearcher: Found matching text (version): 2.9.42
{'Output': {'version': '2.9.42'}}
URLDownloader
{'Input': {'filename': 'SpamSieve-2.9.42.dmg',
           'url': 'https://c-command.com/downloads/SpamSieve-2.9.42.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SpamSieve/downloads/SpamSieve-2.9.42.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SpamSieve/downloads/SpamSieve-2.9.42.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SpamSieve/receipts/SpamSieve.pkg-receipt-20210213-205432.plist

Nothing downloaded, packaged or imported.
```

## ✅ CCleaner/CCleaner.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/CCleaner/CCleaner.pkg.recipe
Processing repos/homebysix-recipes/CCleaner/CCleaner.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(mac/CCMacSetup[\\d]+.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://www.ccleaner.com/ccleaner/download?mac'}}
URLTextSearcher: Found matching text (url): mac/CCMacSetup118.dmg
{'Output': {'url': 'mac/CCMacSetup118.dmg'}}
URLDownloader
{'Input': {'url': 'https://download.ccleaner.com/mac/CCMacSetup118.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CCleaner/downloads/CCMacSetup118.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CCleaner/downloads/CCMacSetup118.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CCleaner/receipts/CCleaner.pkg-receipt-20210213-205434.plist

Nothing downloaded, packaged or imported.
```

## ✅ Caffeine/Caffeine.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Caffeine/Caffeine.pkg.recipe
Processing repos/homebysix-recipes/Caffeine/Caffeine.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'IntelliScape/caffeine'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'Caffeine.dmg' from release '1.1.3'
{'Output': {'release_notes': 'New:\r\n'
                             '- Support for macOS Mojave, Catalina (including '
                             'Dark Mode)\r\n'
                             '- Release is now notarized by Apple.\r\n'
                             '- Hardened Runtime enabled for security.\r\n'
                             '- Updated menu bar icons to improve appearance '
                             'on Retina displays.\r\n'
                             '- Improved experience when prompting for '
                             'accessibility permissions.\r\n'
                             '- Help & Feedback area to enhance user '
                             'support.\r\n'
                             '\r\n'
                             'Fixed:\r\n'
                             '- Icon occasionally remains highlighted after '
                             'closing menu on macOS Sierra and later.',
            'url': 'https://github.com/IntelliScape/caffeine/releases/download/1.1.3/Caffeine.dmg',
            'version': '1.1.3'}}
URLDownloader
{'Input': {'url': 'https://github.com/IntelliScape/caffeine/releases/download/1.1.3/Caffeine.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Caffeine/downloads/Caffeine.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Caffeine/downloads/Caffeine.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Caffeine/receipts/Caffeine.pkg-receipt-20210213-205436.plist

Nothing downloaded, packaged or imported.
```

## ✅ CaseApps/SofaControl.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/CaseApps/SofaControl.pkg.recipe
Processing repos/homebysix-recipes/CaseApps/SofaControl.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'http://www.caseapps.com/downloads/sofacontrol-update.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1561
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.9.6
SparkleUpdateInfoProvider: Found URL http://www.caseapps.com/downloads/updates/SofaControl_Update_Revision1561.dmg
{'Output': {'url': 'http://www.caseapps.com/downloads/updates/SofaControl_Update_Revision1561.dmg',
            'version': '2.9.6'}}
URLDownloader
{'Input': {'filename': 'Sofa Control-2.9.6.dmg',
           'url': 'http://www.caseapps.com/downloads/updates/SofaControl_Update_Revision1561.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SofaControl/downloads/Sofa Control-2.9.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SofaControl/downloads/Sofa '
                        'Control-2.9.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SofaControl/receipts/SofaControl.pkg-receipt-20210213-205437.plist

Nothing downloaded, packaged or imported.
```

## ✅ CaseApps/Tags.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/CaseApps/Tags.pkg.recipe
Processing repos/homebysix-recipes/CaseApps/Tags.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'http://www.caseapps.com/downloads/updates/tags/tags2-update.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3145
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.5.5
SparkleUpdateInfoProvider: Found URL http://www.caseapps.com/downloads/updates/tags/Tags_Update_Revision3145.dmg
{'Output': {'url': 'http://www.caseapps.com/downloads/updates/tags/Tags_Update_Revision3145.dmg',
            'version': '2.5.5'}}
URLDownloader
{'Input': {'filename': 'Tags-2.5.5.dmg',
           'url': 'http://www.caseapps.com/downloads/updates/tags/Tags_Update_Revision3145.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Tags/downloads/Tags-2.5.5.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Tags/downloads/Tags-2.5.5.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Tags/receipts/Tags.pkg-receipt-20210213-205437.plist

Nothing downloaded, packaged or imported.
```

## ✅ ChronoSync/ChronoAgent.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ChronoSync/ChronoAgent.pkg.recipe
Processing repos/homebysix-recipes/ChronoSync/ChronoAgent.pkg.recipe...
URLDownloader
{'Input': {'filename': 'ChronoAgent.dmg',
           'url': 'https://downloads.econtechnologies.com/CA_Mac_Download.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ChronoAgent/downloads/ChronoAgent.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ChronoAgent/downloads/ChronoAgent.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ChronoAgent/receipts/ChronoAgent.pkg-receipt-20210213-205439.plist

Nothing downloaded, packaged or imported.
```

## ✅ ChronoSync/ChronoSync.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ChronoSync/ChronoSync.pkg.recipe
Processing repos/homebysix-recipes/ChronoSync/ChronoSync.pkg.recipe...
URLDownloader
{'Input': {'filename': 'ChronoSync.dmg',
           'url': 'https://downloads.econtechnologies.com/CS4_Download.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ChronoSync/downloads/ChronoSync.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ChronoSync/downloads/ChronoSync.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ChronoSync/receipts/ChronoSync.pkg-receipt-20210213-205439.plist

Nothing downloaded, packaged or imported.
```

## ✅ Cisco/Proximity.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Cisco/Proximity.pkg.recipe
Processing repos/homebysix-recipes/Cisco/Proximity.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Cisco Proximity.dmg',
           'url': 'https://proximity.cisco.com/mac/Proximity.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Proximity/downloads/Cisco Proximity.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Proximity/downloads/Cisco '
                        'Proximity.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Proximity/receipts/Proximity.pkg-receipt-20210213-205441.plist

Nothing downloaded, packaged or imported.
```

## ✅ Cisdem/BetterUnarchiver.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Cisdem/BetterUnarchiver.pkg.recipe
Processing repos/homebysix-recipes/Cisdem/BetterUnarchiver.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'BetterUnarchiver has become Cisdem Unarchiver, '
                              'and new recipes have been created in the '
                              'homebysix-recipes repo.'}}
DeprecationWarning: BetterUnarchiver has become Cisdem Unarchiver, and new recipes have been created in the homebysix-recipes repo.
{'Output': {'deprecation_summary_result': {'data': {'name': 'BetterUnarchiver.pkg',
                                                    'warning': 'BetterUnarchiver '
                                                               'has become '
                                                               'Cisdem '
                                                               'Unarchiver, '
                                                               'and new '
                                                               'recipes have '
                                                               'been created '
                                                               'in the '
                                                               'homebysix-recipes '
                                                               'repo.'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLDownloader
{'Input': {'filename': 'Cisdem BetterUnarchiver.dmg',
           'url': 'https://www.cisdem.com/download/cisdem-betterunarchiver.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.BetterUnarchiver/downloads/Cisdem BetterUnarchiver.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.BetterUnarchiver/downloads/Cisdem '
                        'BetterUnarchiver.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.BetterUnarchiver/receipts/BetterUnarchiver.pkg-receipt-20210213-205442.plist

The following recipes have deprecation warnings:
    Name                  Warning                                                                                                          
    ----                  -------                                                                                                          
    BetterUnarchiver.pkg  BetterUnarchiver has become Cisdem Unarchiver, and new recipes have been created in the homebysix-recipes repo.  
```

## ✅ Cockos/licecap.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Cockos/licecap.pkg.recipe
Processing repos/homebysix-recipes/Cockos/licecap.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'licecap([\\d\\.]+)\\.dmg',
           'result_output_var_name': 'version',
           'url': 'https://www.cockos.com/licecap/'}}
URLTextSearcher: Found matching text (version): 130
{'Output': {'version': '130'}}
URLDownloader
{'Input': {'url': 'https://www.cockos.com/licecap/licecap130.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.licecap/downloads/licecap130.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.licecap/downloads/licecap130.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.licecap/receipts/licecap.pkg-receipt-20210213-205444.plist

Nothing downloaded, packaged or imported.
```

## ✅ Cocktail/Cocktail-10.14.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Cocktail/Cocktail-10.14.pkg.recipe
Processing repos/homebysix-recipes/Cocktail/Cocktail-10.14.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.maintain.se/downloads/sparkle/mojave/mojave.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 12.5
SparkleUpdateInfoProvider: Found URL https://www.maintain.se/downloads/sparkle/mojave/Cocktail_12.5.zip
{'Output': {'url': 'https://www.maintain.se/downloads/sparkle/mojave/Cocktail_12.5.zip',
            'version': '12.5'}}
URLDownloader
{'Input': {'filename': 'Cocktail-12.5.zip',
           'url': 'https://www.maintain.se/downloads/sparkle/mojave/Cocktail_12.5.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Cocktail-10.14/downloads/Cocktail-12.5.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Cocktail-10.14/downloads/Cocktail-12.5.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Cocktail-10.14/receipts/Cocktail-10.14.pkg-receipt-20210213-205446.plist

Nothing downloaded, packaged or imported.
```

## ✅ Cocktail/Cocktail-10.15.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Cocktail/Cocktail-10.15.pkg.recipe
Processing repos/homebysix-recipes/Cocktail/Cocktail-10.15.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.maintain.se/downloads/sparkle/catalina/catalina.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 13.2.6
SparkleUpdateInfoProvider: Found URL https://www.maintain.se/downloads/sparkle/catalina/Cocktail_13.2.6.zip
{'Output': {'url': 'https://www.maintain.se/downloads/sparkle/catalina/Cocktail_13.2.6.zip',
            'version': '13.2.6'}}
URLDownloader
{'Input': {'filename': 'Cocktail-13.2.6.zip',
           'url': 'https://www.maintain.se/downloads/sparkle/catalina/Cocktail_13.2.6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Cocktail-10.15/downloads/Cocktail-13.2.6.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Cocktail-10.15/downloads/Cocktail-13.2.6.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Cocktail-10.15/receipts/Cocktail-10.15.pkg-receipt-20210213-205447.plist

Nothing downloaded, packaged or imported.
```

## ✅ Cocktail/CocktailBigSur.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Cocktail/CocktailBigSur.pkg.recipe
Processing repos/homebysix-recipes/Cocktail/CocktailBigSur.pkg.recipe...
URLDownloader
{'Input': {'url': 'http://usa.maintain.se/Cocktail14BSE.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CocktailBigSur/downloads/Cocktail14BSE.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CocktailBigSur/downloads/Cocktail14BSE.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CocktailBigSur/receipts/CocktailBigSur.pkg-receipt-20210213-205449.plist

Nothing downloaded, packaged or imported.
```

## ✅ CocoaRestClient/CocoaRestClient.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/CocoaRestClient/CocoaRestClient.pkg.recipe
Processing repos/homebysix-recipes/CocoaRestClient/CocoaRestClient.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://mmattozzi.github.io/cocoa-rest-client/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 28
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.4.5
SparkleUpdateInfoProvider: Found URL https://github.com/mmattozzi/cocoa-rest-client/releases/download/1.4.5/CocoaRestClient-1.4.5.dmg
{'Output': {'url': 'https://github.com/mmattozzi/cocoa-rest-client/releases/download/1.4.5/CocoaRestClient-1.4.5.dmg',
            'version': '1.4.5'}}
URLDownloader
{'Input': {'filename': 'CocoaRestClient-1.4.5.dmg',
           'url': 'https://github.com/mmattozzi/cocoa-rest-client/releases/download/1.4.5/CocoaRestClient-1.4.5.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CocoaRestClient/downloads/CocoaRestClient-1.4.5.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CocoaRestClient/downloads/CocoaRestClient-1.4.5.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.CocoaRestClient/receipts/CocoaRestClient.pkg-receipt-20210213-205450.plist

Nothing downloaded, packaged or imported.
```

## ✅ ColorSnapper/ColorSnapper.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ColorSnapper/ColorSnapper.pkg.recipe
Processing repos/homebysix-recipes/ColorSnapper/ColorSnapper.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://s3.amazonaws.com/cs2-appcast/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.6.4
SparkleUpdateInfoProvider: Found URL https://s3.amazonaws.com/cs2-binaries/ColorSnapper2-1_6_4.zip
{'Output': {'url': 'https://s3.amazonaws.com/cs2-binaries/ColorSnapper2-1_6_4.zip',
            'version': '1.6.4'}}
URLDownloader
{'Input': {'filename': 'ColorSnapper2-1.6.4.zip',
           'url': 'https://s3.amazonaws.com/cs2-binaries/ColorSnapper2-1_6_4.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ColorSnapper/downloads/ColorSnapper2-1.6.4.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ColorSnapper/downloads/ColorSnapper2-1.6.4.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ColorSnapper/receipts/ColorSnapper.pkg-receipt-20210213-205452.plist

Nothing downloaded, packaged or imported.
```

## ✅ Contexts/Contexts.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Contexts/Contexts.pkg.recipe
Processing repos/homebysix-recipes/Contexts/Contexts.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://contexts.co/appcasts/stable.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 371
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.7.1
SparkleUpdateInfoProvider: Found URL https://contexts.co/releases/Contexts-3.7.1.dmg
{'Output': {'url': 'https://contexts.co/releases/Contexts-3.7.1.dmg',
            'version': '3.7.1'}}
URLDownloader
{'Input': {'filename': 'Contexts-3.7.1.dmg',
           'url': 'https://contexts.co/releases/Contexts-3.7.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Contexts/downloads/Contexts-3.7.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Contexts/downloads/Contexts-3.7.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Contexts/receipts/Contexts.pkg-receipt-20210213-205454.plist

Nothing downloaded, packaged or imported.
```

## ✅ Deltopia/DeltaWalker.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Deltopia/DeltaWalker.pkg.recipe
Processing repos/homebysix-recipes/Deltopia/DeltaWalker.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https:\\/\\/s3\\.amazonaws\\.com\\/deltawalker\\/DeltaWalker-[\\d\\.]+\\.dmg)"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_14_6) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/12.1.2 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'url',
           'url': 'https://www.deltawalker.com/download.jsp'}}
URLTextSearcher: Found matching text (url): https://s3.amazonaws.com/deltawalker/DeltaWalker-2.5.6.dmg
{'Output': {'url': 'https://s3.amazonaws.com/deltawalker/DeltaWalker-2.5.6.dmg'}}
URLDownloader
{'Input': {'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_14_6) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/12.1.2 '
                                             'Safari/605.1.15'},
           'url': 'https://s3.amazonaws.com/deltawalker/DeltaWalker-2.5.6.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DeltaWalker/downloads/DeltaWalker-2.5.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DeltaWalker/downloads/DeltaWalker-2.5.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DeltaWalker/receipts/DeltaWalker.pkg-receipt-20210213-205455.plist

Nothing downloaded, packaged or imported.
```

## ✅ Docker/DockerToolbox.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Docker/DockerToolbox.pkg.recipe
Processing repos/homebysix-recipes/Docker/DockerToolbox.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'Docker Toolbox has been deprecated and is no '
                              'longer in active development. Please use Docker '
                              'Desktop instead. (Details: '
                              'https://docs.docker.com/docker-for-windows/docker-toolbox/)'}}
DeprecationWarning: Docker Toolbox has been deprecated and is no longer in active development. Please use Docker Desktop instead. (Details: https://docs.docker.com/docker-for-windows/docker-toolbox/)
{'Output': {'deprecation_summary_result': {'data': {'name': 'DockerToolbox.pkg',
                                                    'warning': 'Docker Toolbox '
                                                               'has been '
                                                               'deprecated and '
                                                               'is no longer '
                                                               'in active '
                                                               'development. '
                                                               'Please use '
                                                               'Docker Desktop '
                                                               'instead. '
                                                               '(Details: '
                                                               'https://docs.docker.com/docker-for-windows/docker-toolbox/)'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'DockerToolbox-.+\\.pkg',
           'github_repo': 'docker/toolbox'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'DockerToolbox-.+\.pkg' among asset(s): DockerToolbox-19.03.1.exe, DockerToolbox-19.03.1.pkg, md5sum.txt, sha256sum.txt
GitHubReleasesInfoProvider: Selected asset 'DockerToolbox-19.03.1.pkg' from release 'v19.03.1'
{'Output': {'release_notes': 'Please ensure that your system has all of the '
                             'latest updates before attempting the '
                             'installation.  In some cases, this will require '
                             'a reboot.  If you run into issues creating VMs, '
                             'you may need to uninstall VirtualBox before '
                             're-installing the Docker Toolbox.\r\n'
                             '\r\n'
                             'The following list of components is included '
                             'with this Toolbox release.  If you have a '
                             'previously installed version of Toolbox, these '
                             'installers will update the components to these '
                             'versions.\r\n'
                             '\r\n'
                             '**Included Components**\r\n'
                             '- docker `19.03.1`\r\n'
                             '- docker-machine `0.16.1`\r\n'
                             '- docker-compose `1.24.1`\r\n'
                             '- Kitematic `0.17.7`\r\n'
                             '- Boot2Docker ISO `19.03.1`\r\n'
                             '- VirtualBox `5.2.20`',
            'url': 'https://github.com/docker/toolbox/releases/download/v19.03.1/DockerToolbox-19.03.1.pkg',
            'version': '19.03.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/docker/toolbox/releases/download/v19.03.1/DockerToolbox-19.03.1.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DockerToolbox/downloads/DockerToolbox-19.03.1.pkg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DockerToolbox/downloads/DockerToolbox-19.03.1.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DockerToolbox/receipts/DockerToolbox.pkg-receipt-20210213-205457.plist

The following recipes have deprecation warnings:
    Name               Warning                                                                                                                                                                              
    ----               -------                                                                                                                                                                              
    DockerToolbox.pkg  Docker Toolbox has been deprecated and is no longer in active development. Please use Docker Desktop instead. (Details: https://docs.docker.com/docker-for-windows/docker-toolbox/)  
```

## ✅ Docker/Kitematic.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Docker/Kitematic.pkg.recipe
Processing repos/homebysix-recipes/Docker/Kitematic.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'Docker Toolbox, which included Kitematic, has '
                              'been deprecated and is no longer in active '
                              'development. Please use Docker Desktop instead. '
                              '(Details: '
                              'https://docs.docker.com/docker-for-windows/docker-toolbox/)'}}
DeprecationWarning: Docker Toolbox, which included Kitematic, has been deprecated and is no longer in active development. Please use Docker Desktop instead. (Details: https://docs.docker.com/docker-for-windows/docker-toolbox/)
{'Output': {'deprecation_summary_result': {'data': {'name': 'Kitematic.pkg',
                                                    'warning': 'Docker '
                                                               'Toolbox, which '
                                                               'included '
                                                               'Kitematic, has '
                                                               'been '
                                                               'deprecated and '
                                                               'is no longer '
                                                               'in active '
                                                               'development. '
                                                               'Please use '
                                                               'Docker Desktop '
                                                               'instead. '
                                                               '(Details: '
                                                               'https://docs.docker.com/docker-for-windows/docker-toolbox/)'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\-Mac\\.zip$', 'github_repo': 'docker/kitematic'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '.*\-Mac\.zip$' among asset(s): Kitematic-0.17.13-Mac.zip, Kitematic-0.17.13-Ubuntu.zip, Kitematic-0.17.13-Windows.zip
GitHubReleasesInfoProvider: Selected asset 'Kitematic-0.17.13-Mac.zip' from release 'v0.17.13'
{'Output': {'release_notes': '* fix vulnerabilities',
            'url': 'https://github.com/docker/kitematic/releases/download/v0.17.13/Kitematic-0.17.13-Mac.zip',
            'version': '0.17.13'}}
URLDownloader
{'Input': {'filename': 'Kitematic-0.17.13.zip',
           'url': 'https://github.com/docker/kitematic/releases/download/v0.17.13/Kitematic-0.17.13-Mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.jps3.pkg.Kitematic/downloads/Kitematic-0.17.13.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.jps3.pkg.Kitematic/downloads/Kitematic-0.17.13.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jps3.pkg.Kitematic/receipts/Kitematic.pkg-receipt-20210213-205459.plist

The following recipes have deprecation warnings:
    Name           Warning                                                                                                                                                                                                         
    ----           -------                                                                                                                                                                                                         
    Kitematic.pkg  Docker Toolbox, which included Kitematic, has been deprecated and is no longer in active development. Please use Docker Desktop instead. (Details: https://docs.docker.com/docker-for-windows/docker-toolbox/)  
```

## ✅ Dozer/Dozer.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Dozer/Dozer.pkg.recipe
Processing repos/homebysix-recipes/Dozer/Dozer.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/Mortennn/Dozer/master/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 27
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.0.0
SparkleUpdateInfoProvider: Found URL https://github.com/Mortennn/Dozer/releases/download/v4.0.0/Dozer.4.0.0.dmg
{'Output': {'url': 'https://github.com/Mortennn/Dozer/releases/download/v4.0.0/Dozer.4.0.0.dmg',
            'version': '4.0.0'}}
URLDownloader
{'Input': {'filename': 'Dozer-4.0.0.dmg',
           'url': 'https://github.com/Mortennn/Dozer/releases/download/v4.0.0/Dozer.4.0.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Dozer/downloads/Dozer-4.0.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Dozer/downloads/Dozer-4.0.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Dozer/receipts/Dozer.pkg-receipt-20210213-205500.plist

Nothing downloaded, packaged or imported.
```

## ✅ Elliot Jordan/Recipe Robot.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Elliot\ Jordan/Recipe\ Robot.pkg.recipe
Processing repos/homebysix-recipes/Elliot Jordan/Recipe Robot.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'homebysix/recipe-robot'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'RecipeRobot-2.2.0.dmg' from release 'Recipe Robot 2.2.0'
{'Output': {'release_notes': '### Added\r\n'
                             '\r\n'
                             '- Recipe Robot now incorporates '
                             '[Sparkle](https://sparkle-project.org) for '
                             'keeping itself up to date. (#143)\r\n'
                             '- The app is now built as a universal binary '
                             '(however no testing on Macs with Apple Silicon '
                             'has been done yet).\r\n'
                             '- Verbose output now includes HTTP content-type '
                             'and copying from disk images.\r\n'
                             '\r\n'
                             '### Fixed\r\n'
                             '\r\n'
                             '- Improved code signing authorities parsing, '
                             'which should allow Recipe Robot to capture '
                             'developer names and team identifiers in some '
                             'situations where it would not previously.\r\n'
                             '- Fixed a bug that would prevent using Sparkle '
                             'URLs hosted on updates.devmate.com as input.\r\n'
                             '- Gracefully handle missing file errors during '
                             'installer payload inspection.\r\n'
                             '- Slightly more resilient processing of '
                             'downloaded files when the file format is '
                             'unknown.\r\n'
                             '\r\n'
                             '### Removed\r\n'
                             '\r\n'
                             '- Removed FoundationPlist since Recipe Robot no '
                             'longer depends on it.\r\n',
            'url': 'https://github.com/homebysix/recipe-robot/releases/download/v2.2.0/RecipeRobot-2.2.0.dmg',
            'version': '2.2.0'}}
URLDownloader
{'Input': {'filename': 'Recipe Robot-2.2.0.dmg',
           'url': 'https://github.com/homebysix/recipe-robot/releases/download/v2.2.0/RecipeRobot-2.2.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.RecipeRobot/downloads/Recipe Robot-2.2.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.RecipeRobot/downloads/Recipe '
                        'Robot-2.2.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.RecipeRobot/receipts/Recipe Robot.pkg-receipt-20210213-205502.plist

Nothing downloaded, packaged or imported.
```

## ✅ Emailchemy/Emailchemy.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Emailchemy/Emailchemy.pkg.recipe
Processing repos/homebysix-recipes/Emailchemy/Emailchemy.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Emailchemy.dmg',
           'url': 'https://s3.amazonaws.com/wksdownload/Emailchemy-Mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Emailchemy/downloads/Emailchemy.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Emailchemy/downloads/Emailchemy.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Emailchemy/receipts/Emailchemy.pkg-receipt-20210213-205502.plist

Nothing downloaded, packaged or imported.
```

## ✅ Flinto/Flinto.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Flinto/Flinto.pkg.recipe
Processing repos/homebysix-recipes/Flinto/Flinto.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Flinto.dmg',
           'url': 'https://www.flinto.com/download_latest'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Flinto/downloads/Flinto.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Flinto/downloads/Flinto.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Flinto/receipts/Flinto.pkg-receipt-20210213-205504.plist

Nothing downloaded, packaged or imported.
```

## ✅ FoldingText/FoldingText.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/FoldingText/FoldingText.pkg.recipe
Processing repos/homebysix-recipes/FoldingText/FoldingText.pkg.recipe...
URLDownloader
{'Input': {'filename': 'FoldingText.dmg',
           'url': 'https://s3.amazonaws.com/foldingtext/FoldingText.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FoldingText/downloads/FoldingText.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FoldingText/downloads/FoldingText.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FoldingText/receipts/FoldingText.pkg-receipt-20210213-205506.plist

Nothing downloaded, packaged or imported.
```

## ✅ GB Studio/GB Studio.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/GB\ Studio/GB\ Studio.pkg.recipe
Processing repos/homebysix-recipes/GB Studio/GB Studio.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\-darwin\\-x64\\-.*\\.zip$',
           'github_repo': 'chrismaltby/gb-studio'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '.*\-darwin\-x64\-.*\.zip$' among asset(s): gb-studio-1.1.0.x86_64.rpm, gb-studio_1.1.0_amd64.deb, GB.Studio-darwin-x64-1.1.0.zip, GB.Studio-win32-ia32-1.1.0.zip, GB.Studio-win32-ia32-squirrel-1.1.0.zip, GB.Studio-win32-x64-1.1.0.zip, GB.Studio-win32-x64-squirrel-1.1.0.zip
GitHubReleasesInfoProvider: Selected asset 'GB.Studio-darwin-x64-1.1.0.zip' from release 'GB Studio v1.1.0'
{'Output': {'release_notes': 'GB Studio is a free and easy to use retro '
                             'adventure game creator for your favourite '
                             'handheld video game system.\r\n'
                             '\r\n'
                             '## [1.1.0]\r\n'
                             '\r\n'
                             '### Added\r\n'
                             '\r\n'
                             '- Support for animating sprites by cycling '
                             'between frames of animation.\r\n'
                             '- Ability to use variables in text by using new '
                             'variable id placeholders "You have $01$ '
                             'gold".\r\n'
                             '- Events for Saving and Loading your game.\r\n'
                             '- Event for attaching scripts to button '
                             'inputs.\r\n'
                             '- Extra actor commands for setting relative '
                             'position, check facing direction. '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Math commands, random numbers, add, subtract, '
                             'multiply and divide variables with each other '
                             'other and much more. '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Events for pushing and popping scenes from a '
                             'stack allowing nested menus to be created '
                             'returning back to your initial position when '
                             'closed. '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Event to invoke a script from another actor. '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Pan around world viewer using Alt + click, '
                             'middle click or by clicking and dragging in the '
                             'space between scenes.\r\n'
                             '- Ability to control zoom using pinch gestures '
                             'or Ctrl + Mouse Wheel '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Drag and drop actors and triggers between '
                             'scenes.\r\n'
                             '- Ability to type text directly into Add Event '
                             'search and have it create a new Display Text '
                             'module with the text you entered.\r\n'
                             '- Event for controlling text open, draw and '
                             'close animation speeds. '
                             '[@RichardULZ](https://github.com/RichardULZ)\r\n'
                             '- All script events are now collapsable and can '
                             'be renamed.\r\n'
                             '- Dark mode theme selection to Windows and '
                             'Linux.\r\n'
                             '- Ability to select GameBoy cartridge type.\r\n'
                             '- Ability to control movement and animation '
                             'speed of actors.\r\n'
                             '- Support for copy and paste for scenes, actors, '
                             'triggers and scripts.\r\n'
                             '- Event groups allowing you to better organise '
                             'your scripts.\r\n'
                             '- Notes fields to project, scenes, actors and '
                             'triggers. '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Splash page now has a list of recently opened '
                             'projects.\r\n'
                             '- Editor sidebar now resizable. '
                             '[@thomas-alrek](https://github.com/thomas-alrek)\r\n'
                             '- Support for 32-bit Windows.\r\n'
                             '- Support for localisation of the app (now '
                             'accepting pull requests for all languages).\r\n'
                             '- Chinese localisation. '
                             '[@InchouRyu](https://github.com/InchouRyu)\r\n'
                             '- Brazilian Portuguese localisation '
                             '[@junkajii](https://github.com/junkajii)\r\n'
                             '- Portuguese localisation '
                             '[@toxworks](https://github.com/toxworks)\r\n'
                             '\r\n'
                             '### Changed\r\n'
                             '\r\n'
                             '- Display text event now supports up to 3 lines '
                             'of text.\r\n'
                             "- Warnings when image assets don't follow "
                             'specifications are now more noticeable in build '
                             'phase.\r\n'
                             '\r\n'
                             '### Fixed\r\n'
                             '\r\n'
                             '- Fixed audio bugs in emulator where sound would '
                             'pop as emulator opened and closed.\r\n'
                             '- Fixed vsync tearing. '
                             '[@RichardULZ](https://github.com/RichardULZ)\r\n'
                             '- Input handling fixes on Windows build.\r\n'
                             '- Lots of other bug fixes.',
            'url': 'https://github.com/chrismaltby/gb-studio/releases/download/v1.1.0/GB.Studio-darwin-x64-1.1.0.zip',
            'version': '1.1.0'}}
URLDownloader
{'Input': {'filename': 'GB Studio-1.1.0.zip',
           'url': 'https://github.com/chrismaltby/gb-studio/releases/download/v1.1.0/GB.Studio-darwin-x64-1.1.0.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GBStudio/downloads/GB Studio-1.1.0.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GBStudio/downloads/GB '
                        'Studio-1.1.0.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GBStudio/receipts/GB Studio.pkg-receipt-20210213-205507.plist

Nothing downloaded, packaged or imported.
```

## ✅ GitHub/GitHubCLI.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/GitHub/GitHubCLI.pkg.recipe
Processing repos/homebysix-recipes/GitHub/GitHubCLI.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'gh_[\\d\\.]+_macOS_amd64\\.tar\\.gz',
           'github_repo': 'cli/cli'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'gh_[\d\.]+_macOS_amd64\.tar\.gz' among asset(s): gh_1.5.0_checksums.txt, gh_1.5.0_linux_386.deb, gh_1.5.0_linux_386.rpm, gh_1.5.0_linux_386.tar.gz, gh_1.5.0_linux_amd64.deb, gh_1.5.0_linux_amd64.rpm, gh_1.5.0_linux_amd64.tar.gz, gh_1.5.0_linux_arm64.deb, gh_1.5.0_linux_arm64.rpm, gh_1.5.0_linux_arm64.tar.gz, gh_1.5.0_linux_armv6.deb, gh_1.5.0_linux_armv6.rpm, gh_1.5.0_linux_armv6.tar.gz, gh_1.5.0_macOS_amd64.tar.gz, gh_1.5.0_windows_386.zip, gh_1.5.0_windows_amd64.msi, gh_1.5.0_windows_amd64.zip
GitHubReleasesInfoProvider: Selected asset 'gh_1.5.0_macOS_amd64.tar.gz' from release 'GitHub CLI 1.5.0'
{'Output': {'release_notes': '## New Commands\r\n'
                             '\r\n'
                             '### Add ability to comment on issues and pull '
                             'requests (#2535, #2776)\r\n'
                             '`gh issue comment` and `gh pr comment` commands '
                             'are now available\r\n'
                             '\r\n'
                             '### Add ability to clone gists (#2222)\r\n'
                             '`gh gist clone` is now available\r\n'
                             '\r\n'
                             '## New Features\r\n'
                             '* `pr view`: Display top level review comments '
                             'inline with regular comments #2757\r\n'
                             '\r\n'
                             '* `repo fork`: Add ability to specify fork '
                             'remote name #1882\r\n'
                             '\r\n'
                             '* `pr merge`: Add ability to delete local branch '
                             'for previously merged PRs (#2789, #2798)\r\n'
                             '\r\n'
                             '## Fixes\r\n'
                             '\r\n'
                             '* `auth`: Add more descriptive error messaging '
                             'when aborting due to environment variables '
                             '#2813\r\n'
                             '\r\n'
                             '* `completion`: Improve docs for bash, zsh, fish '
                             '#2636\r\n'
                             '\r\n'
                             '* `version`: Output link to correct tagged '
                             'release #2638\r\n'
                             '\r\n'
                             '* Update notification avoids incorrect '
                             'notifications when gh is built from source #2812',
            'url': 'https://github.com/cli/cli/releases/download/v1.5.0/gh_1.5.0_macOS_amd64.tar.gz',
            'version': '1.5.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/cli/cli/releases/download/v1.5.0/gh_1.5.0_macOS_amd64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GitHubCLI/downloads/gh_1.5.0_macOS_amd64.tar.gz
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GitHubCLI/downloads/gh_1.5.0_macOS_amd64.tar.gz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GitHubCLI/receipts/GitHubCLI.pkg-receipt-20210213-205509.plist

Nothing downloaded, packaged or imported.
```

## ✅ Grammarly/Grammarly.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Grammarly/Grammarly.pkg.recipe
Processing repos/homebysix-recipes/Grammarly/Grammarly.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Grammarly.dmg',
           'url': 'https://download-editor.grammarly.com/osx/Grammarly.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Grammarly/downloads/Grammarly.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Grammarly/downloads/Grammarly.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Grammarly/receipts/Grammarly.pkg-receipt-20210213-205510.plist

Nothing downloaded, packaged or imported.
```

## ✅ GrandPerspective/GrandPerspective.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/GrandPerspective/GrandPerspective.pkg.recipe
Processing repos/homebysix-recipes/GrandPerspective/GrandPerspective.pkg.recipe...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': 'GrandPerspective-[0-9_\\.]*\\.dmg',
           'SOURCEFORGE_PROJECT_ID': 148156}}
SourceForgeURLProvider: File URL https://sourceforge.net/projects/grandperspectiv/files/grandperspective/2.5.4/GrandPerspective-2_5_4.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/grandperspectiv/files/grandperspective/2.5.4/GrandPerspective-2_5_4.dmg/download'}}
URLDownloader
{'Input': {'filename': 'GrandPerspective.dmg',
           'url': 'https://sourceforge.net/projects/grandperspectiv/files/grandperspective/2.5.4/GrandPerspective-2_5_4.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 21 Nov 2020 10:11:50 GMT
URLDownloader: Storing new ETag header: "5fb8e7e6-2b0b5e"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GrandPerspective/downloads/GrandPerspective.dmg
{'Output': {'download_changed': True,
            'etag': '"5fb8e7e6-2b0b5e"',
            'last_modified': 'Sat, 21 Nov 2020 10:11:50 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GrandPerspective/downloads/GrandPerspective.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GrandPerspective/downloads/GrandPerspective.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GrandPerspective/receipts/GrandPerspective.pkg-receipt-20210213-205515.plist

The following new items were downloaded:
    Download Path                                                                                                  
    -------------                                                                                                  
    ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.GrandPerspective/downloads/GrandPerspective.dmg  
```

## ✅ HazeOver/HazeOver.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/HazeOver/HazeOver.pkg.recipe
Processing repos/homebysix-recipes/HazeOver/HazeOver.pkg.recipe...
URLDownloader
{'Input': {'filename': 'HazeOver.tgz',
           'url': 'https://hazeover.com/get/HazeOver.txz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HazeOver/downloads/HazeOver.tgz
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HazeOver/downloads/HazeOver.tgz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HazeOver/receipts/HazeOver.pkg-receipt-20210213-205516.plist

Nothing downloaded, packaged or imported.
```

## ✅ Karelia/TheHitList.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Karelia/TheHitList.pkg.recipe
Processing repos/homebysix-recipes/Karelia/TheHitList.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 367
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.1.32
SparkleUpdateInfoProvider: Found URL https://distrib.karelia.com/downloads/TheHitList-367.zip
{'Output': {'url': 'https://distrib.karelia.com/downloads/TheHitList-367.zip',
            'version': '1.1.32'}}
URLDownloader
{'Input': {'filename': 'The Hit List-1.1.32.zip',
           'url': 'https://distrib.karelia.com/downloads/TheHitList-367.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TheHitList/downloads/The Hit List-1.1.32.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TheHitList/downloads/The '
                        'Hit List-1.1.32.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TheHitList/receipts/TheHitList.pkg-receipt-20210213-205517.plist

Nothing downloaded, packaged or imported.
```

## ✅ KeePassX/KeePassX.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/KeePassX/KeePassX.pkg.recipe
Processing repos/homebysix-recipes/KeePassX/KeePassX.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '"latest_version">Latest version: ([\\d\\.]+)<',
           'result_output_var_name': 'version',
           'url': 'https://www.keepassx.org/downloads/'}}
URLTextSearcher: Found matching text (version): 2.0.3
{'Output': {'version': '2.0.3'}}
URLDownloader
{'Input': {'filename': 'KeePassX.dmg',
           'url': 'https://www.keepassx.org/releases/2.0.3/KeePassX-2.0.3.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.KeePassX/downloads/KeePassX.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.KeePassX/downloads/KeePassX.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.KeePassX/receipts/KeePassX.pkg-receipt-20210213-205520.plist

Nothing downloaded, packaged or imported.
```

## ✅ Kite/Kite.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Kite/Kite.pkg.recipe
Processing repos/homebysix-recipes/Kite/Kite.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://release.kite.com/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 0.20210128.0
SparkleUpdateInfoProvider: Found URL https://kitedownloads.b-cdn.net/mac/0.20210128.0/Kite.dmg
{'Output': {'url': 'https://kitedownloads.b-cdn.net/mac/0.20210128.0/Kite.dmg',
            'version': '0.20210128.0'}}
URLDownloader
{'Input': {'filename': 'Kite-0.20210128.0.dmg',
           'url': 'https://kitedownloads.b-cdn.net/mac/0.20210128.0/Kite.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Kite/downloads/Kite-0.20210128.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Kite/downloads/Kite-0.20210128.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Kite/receipts/Kite.pkg-receipt-20210213-205521.plist

Nothing downloaded, packaged or imported.
```

## ✅ MacPaw/Gemini2.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/MacPaw/Gemini2.pkg.recipe
Processing repos/homebysix-recipes/MacPaw/Gemini2.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Gemini 2.dmg',
           'url': 'https://dl.devmate.com/com.macpaw.site.Gemini2/Gemini2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Gemini2/downloads/Gemini 2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Gemini2/downloads/Gemini '
                        '2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Gemini2/receipts/Gemini2.pkg-receipt-20210213-205522.plist

Nothing downloaded, packaged or imported.
```

## ✅ MacTerm/MacTerm.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/MacTerm/MacTerm.pkg.recipe
Processing repos/homebysix-recipes/MacTerm/MacTerm.pkg.recipe...
URLDownloader
{'Input': {'filename': 'MacTerm.dmg',
           'url': 'https://www.macterm.net/updates/macterm-latest.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.MacTerm/downloads/MacTerm.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.MacTerm/downloads/MacTerm.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.MacTerm/receipts/MacTerm.pkg-receipt-20210213-205523.plist

Nothing downloaded, packaged or imported.
```

## ✅ Macroplant/Adapter.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Macroplant/Adapter.pkg.recipe
Processing repos/homebysix-recipes/Macroplant/Adapter.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Adapter.dmg',
           'url': 'https://www.macroplant.com/latest-binaries/adapter-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Adapter/downloads/Adapter.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Adapter/downloads/Adapter.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Adapter/receipts/Adapter.pkg-receipt-20210213-205525.plist

Nothing downloaded, packaged or imported.
```

## ✅ Malwarebytes/Malwarebytes.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Malwarebytes/Malwarebytes.pkg.recipe
Processing repos/homebysix-recipes/Malwarebytes/Malwarebytes.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Malwarebytes.pkg',
           'url': 'https://downloads.malwarebytes.com/file/mb-mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 21 Jan 2021 18:15:38 GMT
URLDownloader: Storing new ETag header: "1f29ae5-5b96d0f03f372"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Malwarebytes/downloads/Malwarebytes.pkg
{'Output': {'download_changed': True,
            'etag': '"1f29ae5-5b96d0f03f372"',
            'last_modified': 'Thu, 21 Jan 2021 18:15:38 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Malwarebytes/downloads/Malwarebytes.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Malwarebytes/downloads/Malwarebytes.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Malwarebytes/receipts/Malwarebytes.pkg-receipt-20210213-205529.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Malwarebytes/downloads/Malwarebytes.pkg  
```

## ✅ ManyTricks/Butler.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Butler.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Butler.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/butler/butlercast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 5096
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.3.3
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/butler433.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/butler433.dmg',
            'version': '4.3.3'}}
URLDownloader
{'Input': {'filename': 'Butler-4.3.3.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/butler433.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Butler/downloads/Butler-4.3.3.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Butler/downloads/Butler-4.3.3.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Butler/receipts/Butler.pkg-receipt-20210213-205530.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/DesktopCurtain.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/DesktopCurtain.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/DesktopCurtain.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/desktopcurtain/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3187
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.0.9
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/desktopcurtain309.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/desktopcurtain309.dmg',
            'version': '3.0.9'}}
URLDownloader
{'Input': {'filename': 'Desktop Curtain-3.0.9.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/desktopcurtain309.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DesktopCurtain/downloads/Desktop Curtain-3.0.9.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DesktopCurtain/downloads/Desktop '
                        'Curtain-3.0.9.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DesktopCurtain/receipts/DesktopCurtain.pkg-receipt-20210213-205531.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/Displaperture.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Displaperture.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Displaperture.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Displaperture.dmg',
           'url': 'https://manytricks.com/download/displaperture'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Displaperture/downloads/Displaperture.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Displaperture/downloads/Displaperture.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Displaperture/receipts/Displaperture.pkg-receipt-20210213-205532.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/KeyCodes.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/KeyCodes.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/KeyCodes.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/keycodes/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2026
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.2
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/keycodes220.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/keycodes220.dmg',
            'version': '2.2'}}
URLDownloader
{'Input': {'filename': 'Key Codes-2.2.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/keycodes220.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.KeyCodes/downloads/Key Codes-2.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.KeyCodes/downloads/Key '
                        'Codes-2.2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.KeyCodes/receipts/KeyCodes.pkg-receipt-20210213-205533.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/Keymou.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Keymou.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Keymou.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/keymou/appcast/?version=1'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1130
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.2.8
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/keymou128.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/keymou128.dmg',
            'version': '1.2.8'}}
URLDownloader
{'Input': {'filename': 'Keymou-1.2.8.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/keymou128.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Keymo/downloads/Keymou-1.2.8.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Keymo/downloads/Keymou-1.2.8.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Keymo/receipts/Keymou.pkg-receipt-20210213-205534.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/Leech.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Leech.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Leech.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/leech/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3140
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.1.4
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/leech314.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/leech314.dmg',
            'version': '3.1.4'}}
URLDownloader
{'Input': {'filename': 'Leech-3.1.4.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/leech314.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Leech/downloads/Leech-3.1.4.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Leech/downloads/Leech-3.1.4.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Leech/receipts/Leech.pkg-receipt-20210213-205536.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/Moom.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Moom.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Moom.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/moom/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3301
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.2.20
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/moom3220.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/moom3220.dmg',
            'version': '3.2.20'}}
URLDownloader
{'Input': {'filename': 'Moom-3.2.20.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/moom3220.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Moom/downloads/Moom-3.2.20.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Moom/downloads/Moom-3.2.20.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Moom/receipts/Moom.pkg-receipt-20210213-205537.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/NameMangler.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/NameMangler.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/NameMangler.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/namemangler/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3285
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.6
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/namemangler360.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/namemangler360.dmg',
            'version': '3.6'}}
URLDownloader
{'Input': {'filename': 'Name Mangler-3.6.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/namemangler360.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NameMangler/downloads/Name Mangler-3.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NameMangler/downloads/Name '
                        'Mangler-3.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NameMangler/receipts/NameMangler.pkg-receipt-20210213-205538.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/OpenWithManager.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/OpenWithManager.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/OpenWithManager.pkg.recipe...
URLDownloader
{'Input': {'filename': 'openwithmanager.dmg',
           'url': 'https://manytricks.com/download/openwithmanager'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.OpenWithManager/downloads/openwithmanager.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.OpenWithManager/downloads/openwithmanager.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.OpenWithManager/receipts/OpenWithManager.pkg-receipt-20210213-205539.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/Resolutionator.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Resolutionator.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Resolutionator.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/resolutionator/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 115
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.0.1
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/resolutionator201.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/resolutionator201.dmg',
            'version': '2.0.1'}}
URLDownloader
{'Input': {'filename': 'Resolutionator-2.0.1.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/resolutionator201.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Resolutionator/downloads/Resolutionator-2.0.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Resolutionator/downloads/Resolutionator-2.0.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Resolutionator/receipts/Resolutionator.pkg-receipt-20210213-205540.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/TimeSink.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/TimeSink.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/TimeSink.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/timesink/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1318
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.1
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/timesink210.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/timesink210.dmg',
            'version': '2.1'}}
URLDownloader
{'Input': {'filename': 'Time Sink-2.1.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/timesink210.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TimeSink/downloads/Time Sink-2.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TimeSink/downloads/Time '
                        'Sink-2.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TimeSink/receipts/TimeSink.pkg-receipt-20210213-205541.plist

Nothing downloaded, packaged or imported.
```

## ✅ ManyTricks/Usher.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ManyTricks/Usher.pkg.recipe
Processing repos/homebysix-recipes/ManyTricks/Usher.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://manytricks.com/usher/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 4595
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.0 Beta 4595
SparkleUpdateInfoProvider: Found URL https://manytricks.com/download/_do_not_hotlink_/_beta_/usher4595.dmg
{'Output': {'url': 'https://manytricks.com/download/_do_not_hotlink_/_beta_/usher4595.dmg',
            'version': '2.0 Beta 4595'}}
URLDownloader
{'Input': {'filename': 'Usher-2.0 Beta 4595.dmg',
           'url': 'https://manytricks.com/download/_do_not_hotlink_/_beta_/usher4595.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 13 Feb 2021 10:36:28 GMT
URLDownloader: Storing new ETag header: "f86ad8-5bb35534bcd8c"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Usher/downloads/Usher-2.0 Beta 4595.dmg
{'Output': {'download_changed': True,
            'etag': '"f86ad8-5bb35534bcd8c"',
            'last_modified': 'Sat, 13 Feb 2021 10:36:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Usher/downloads/Usher-2.0 '
                        'Beta 4595.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Usher/downloads/Usher-2.0 '
                                                                        'Beta '
                                                                        '4595.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Usher/receipts/Usher.pkg-receipt-20210213-205544.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Usher/downloads/Usher-2.0 Beta 4595.dmg  
```

## ✅ Mellel/Mellel.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Mellel/Mellel.pkg.recipe
Processing repos/homebysix-recipes/Mellel/Mellel.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(https://d1riogbqt3a9uw\\.cloudfront\\.net/mellel_[\\w]+\\.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://www.mellel.com/thanks-for-downloading'}}
URLTextSearcher: Found matching text (url): https://d1riogbqt3a9uw.cloudfront.net/mellel_50505.dmg
{'Output': {'url': 'https://d1riogbqt3a9uw.cloudfront.net/mellel_50505.dmg'}}
URLDownloader
{'Input': {'filename': 'Mellel.dmg',
           'url': 'https://d1riogbqt3a9uw.cloudfront.net/mellel_50505.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Mellel/downloads/Mellel.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Mellel/downloads/Mellel.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Mellel/receipts/Mellel.pkg-receipt-20210213-205547.plist

Nothing downloaded, packaged or imported.
```

## ✅ MyMixApps/FilePane.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/MyMixApps/FilePane.pkg.recipe
Processing repos/homebysix-recipes/MyMixApps/FilePane.pkg.recipe...
URLDownloader
{'Input': {'filename': 'FilePane.dmg',
           'url': 'https://dl.devmate.com/com.mymixapps.FilePane/FilePane.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FilePane/downloads/FilePane.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FilePane/downloads/FilePane.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FilePane/receipts/FilePane.pkg-receipt-20210213-205548.plist

Nothing downloaded, packaged or imported.
```

## ❌ NetSurf/NetSurf.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/NetSurf/NetSurf.pkg.recipe
Processing repos/homebysix-recipes/NetSurf/NetSurf.pkg.recipe...
DeprecationWarning
{'Input': {}}
DeprecationWarning: ### This recipe has been deprecated. It may be removed soon. ###
{'Output': {'deprecation_summary_result': {'data': {'name': 'NetSurf.pkg',
                                                    'warning': '### This '
                                                               'recipe has '
                                                               'been '
                                                               'deprecated. It '
                                                               'may be removed '
                                                               'soon. ###'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLTextSearcher
{'Input': {'re_pattern': '/netsurf/releases/pre-built/macosx/NetSurf-([\\d\\.]+)\\.dmg',
           'result_output_var_name': 'version',
           'url': 'http://www.netsurf-browser.org/downloads/macosx/'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NetSurf/receipts/NetSurf.pkg-receipt-20210213-205550.plist

The following recipes failed:
    repos/homebysix-recipes/NetSurf/NetSurf.pkg.recipe
        Error in com.github.homebysix.pkg.NetSurf: Processor: URLTextSearcher: Error: No match found on URL: http://www.netsurf-browser.org/downloads/macosx/

The following recipes have deprecation warnings:
    Name         Warning                                                           
    ----         -------                                                           
    NetSurf.pkg  ### This recipe has been deprecated. It may be removed soon. ###  
```

## ✅ NightOwl/NightOwl.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/NightOwl/NightOwl.pkg.recipe
Processing repos/homebysix-recipes/NightOwl/NightOwl.pkg.recipe...
URLDownloader
{'Input': {'filename': 'NightOwl.dmg',
           'url': 'https://nightowl.kramser.xyz/files/NightOwl.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NightOwl/downloads/NightOwl.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NightOwl/downloads/NightOwl.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NightOwl/receipts/NightOwl.pkg-receipt-20210213-205552.plist

Nothing downloaded, packaged or imported.
```

## ✅ ObjectiveDevelopment/LaunchBar.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ObjectiveDevelopment/LaunchBar.pkg.recipe
Processing repos/homebysix-recipes/ObjectiveDevelopment/LaunchBar.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(LaunchBar-[\\d\\.]+.dmg)',
           'result_output_var_name': 'match',
           'url': 'https://www.obdev.at/products/launchbar/download.html'}}
URLTextSearcher: Found matching text (match): LaunchBar-6.13.1.dmg
{'Output': {'match': 'LaunchBar-6.13.1.dmg'}}
URLDownloader
{'Input': {'filename': 'LaunchBar.dmg',
           'url': 'https://www.obdev.at/downloads/launchbar/LaunchBar-6.13.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.LaunchBar/downloads/LaunchBar.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.LaunchBar/downloads/LaunchBar.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.LaunchBar/receipts/LaunchBar.pkg-receipt-20210213-205554.plist

Nothing downloaded, packaged or imported.
```

## ✅ Open in Atom/Open in Atom.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Open\ in\ Atom/Open\ in\ Atom.pkg.recipe
Processing repos/homebysix-recipes/Open in Atom/Open in Atom.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'cdzombak/finder-atom'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'Open.in.Atom.zip' from release 'finder-atom 2.0'
{'Output': {'release_notes': '**This release is compatible with macOS '
                             'Sierra.** See [the '
                             'README](https://github.com/cdzombak/finder-atom#macos-sierra-1012-incompatibility) '
                             'for a discussion of v2.0. For OS X 10.11, use '
                             '[the 1.2 '
                             'release](https://github.com/cdzombak/finder-atom/releases/tag/v1.2).\r\n'
                             '\r\n'
                             '• Implement “Open in Atom” as an AppleScript '
                             'which can be used on macOS Sierra. '
                             '([#3](https://github.com/cdzombak/finder-atom/issues/3))\r\n'
                             '\r\n',
            'url': 'https://github.com/cdzombak/finder-atom/releases/download/v2.0/Open.in.Atom.zip',
            'version': '2.0'}}
URLDownloader
{'Input': {'filename': 'Open in Atom-2.0.zip',
           'url': 'https://github.com/cdzombak/finder-atom/releases/download/v2.0/Open.in.Atom.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.OpeninAtomforFinder/downloads/Open in Atom-2.0.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.OpeninAtomforFinder/downloads/Open '
                        'in Atom-2.0.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.OpeninAtomforFinder/receipts/Open in Atom.pkg-receipt-20210213-205555.plist

Nothing downloaded, packaged or imported.
```

## ✅ PDFKit/PDFKit.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/PDFKit/PDFKit.pkg.recipe
Processing repos/homebysix-recipes/PDFKit/PDFKit.pkg.recipe...
URLDownloader
{'Input': {'filename': 'PDFKit.dmg',
           'url': 'https://www.ireador.com/downloads/PDFKit.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.PDFKit/downloads/PDFKit.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.PDFKit/downloads/PDFKit.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.PDFKit/receipts/PDFKit.pkg-receipt-20210213-205556.plist

Nothing downloaded, packaged or imported.
```

## ✅ Pandora/Pandora.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Pandora/Pandora.pkg.recipe
Processing repos/homebysix-recipes/Pandora/Pandora.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Pandora.dmg',
           'url': 'https://pdora.co/desktop_mac_download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Pandora/downloads/Pandora.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Pandora/downloads/Pandora.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Pandora/receipts/Pandora.pkg-receipt-20210213-205557.plist

Nothing downloaded, packaged or imported.
```

## ✅ Papers/Papers.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Papers/Papers.pkg.recipe
Processing repos/homebysix-recipes/Papers/Papers.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'Papers_Setup_([\\d\\.]+)\\.dmg',
           'result_output_var_name': 'version',
           'url': 'https://update.readcube.com/desktop/updates/latest-mac.yml'}}
URLTextSearcher: Found matching text (version): 4.22.2
{'Output': {'version': '4.22.2'}}
URLDownloader
{'Input': {'filename': 'Papers-4.22.2.dmg',
           'url': 'https://update.readcube.com/desktop/updates/Papers_Setup_4.22.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Papers/downloads/Papers-4.22.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Papers/downloads/Papers-4.22.2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Papers/receipts/Papers.pkg-receipt-20210213-205558.plist

Nothing downloaded, packaged or imported.
```

## ✅ Pingendo/Pingendo.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Pingendo/Pingendo.pkg.recipe
Processing repos/homebysix-recipes/Pingendo/Pingendo.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.dmg$', 'github_repo': 'Pingendo/pingendo'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '.*\.dmg$' among asset(s): latest-linux.yml, latest-mac.yml, latest.yml, Pingendo-4.3.2-mac.zip, Pingendo-4.3.2-x86_64.AppImage, Pingendo-4.3.2.dmg, Pingendo-4.3.2.dmg.blockmap, Pingendo-Setup-4.3.2.exe, Pingendo-Setup-4.3.2.exe.blockmap
GitHubReleasesInfoProvider: Selected asset 'Pingendo-4.3.2.dmg' from release '4.3.2'
{'Output': {'url': 'https://github.com/Pingendo/pingendo/releases/download/v4.3.2/Pingendo-4.3.2.dmg',
            'version': '4.3.2'}}
URLDownloader
{'Input': {'filename': 'Pingendo-4.3.2.dmg',
           'url': 'https://github.com/Pingendo/pingendo/releases/download/v4.3.2/Pingendo-4.3.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Pingendo/downloads/Pingendo-4.3.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Pingendo/downloads/Pingendo-4.3.2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Pingendo/receipts/Pingendo.pkg-receipt-20210213-205600.plist

Nothing downloaded, packaged or imported.
```

## ✅ Plug/Plug.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Plug/Plug.pkg.recipe
Processing repos/homebysix-recipes/Plug/Plug.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.plugformac.com/updates/plug2/sparklecast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2067
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: Version 2.0.19
SparkleUpdateInfoProvider: Found URL https://www.plugformac.com/updates/plug2/Plug-2067.dmg
{'Output': {'url': 'https://www.plugformac.com/updates/plug2/Plug-2067.dmg',
            'version': 'Version 2.0.19'}}
URLDownloader
{'Input': {'filename': 'Plug-Version 2.0.19.dmg',
           'url': 'https://www.plugformac.com/updates/plug2/Plug-2067.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Plug/downloads/Plug-Version 2.0.19.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Plug/downloads/Plug-Version '
                        '2.0.19.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Plug/receipts/Plug.pkg-receipt-20210213-205602.plist

Nothing downloaded, packaged or imported.
```

## ✅ Postbox/Postbox.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Postbox/Postbox.pkg.recipe
Processing repos/homebysix-recipes/Postbox/Postbox.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '\\"(?P<download_url>https://.*\\.dmg)\\"',
           'url': 'https://www.postbox-inc.com/download/success-mac'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (download_url): https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.46-mac64.dmg
URLTextSearcher: Found matching text (match): https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.46-mac64.dmg
{'Output': {'download_url': 'https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.46-mac64.dmg',
            'match': 'https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.46-mac64.dmg'}}
URLDownloader
{'Input': {'filename': 'Postbox.dmg',
           'url': 'https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.46-mac64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Postbox/downloads/Postbox.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Postbox/downloads/Postbox.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Postbox/receipts/Postbox.pkg-receipt-20210213-205604.plist

Nothing downloaded, packaged or imported.
```

## ✅ Quip/Quip.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Quip/Quip.pkg.recipe
Processing repos/homebysix-recipes/Quip/Quip.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Quip.dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11_0)'},
           'url': 'https://quip.com/downloads/auto'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Quip/downloads/Quip.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Quip/downloads/Quip.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Quip/receipts/Quip.pkg-receipt-20210213-205605.plist

Nothing downloaded, packaged or imported.
```

## ✅ Reinvented/Feeder3.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Reinvented/Feeder3.pkg.recipe
Processing repos/homebysix-recipes/Reinvented/Feeder3.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://reinventedsoftware.com/feeder/downloads/Feeder3.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3340
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.7.5
SparkleUpdateInfoProvider: Found URL https://reinventedsoftware.com/feeder/downloads/Feeder_3.7.5.dmg
{'Output': {'url': 'https://reinventedsoftware.com/feeder/downloads/Feeder_3.7.5.dmg',
            'version': '3.7.5'}}
URLDownloader
{'Input': {'filename': 'Feeder 3-3.7.5.dmg',
           'url': 'https://reinventedsoftware.com/feeder/downloads/Feeder_3.7.5.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Feeder3/downloads/Feeder 3-3.7.5.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Feeder3/downloads/Feeder '
                        '3-3.7.5.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Feeder3/receipts/Feeder3.pkg-receipt-20210213-205606.plist

Nothing downloaded, packaged or imported.
```

## ✅ Reinvented/Feeder4.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Reinvented/Feeder4.pkg.recipe
Processing repos/homebysix-recipes/Reinvented/Feeder4.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://reinventedsoftware.com/feeder/downloads/Feeder4.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 5260
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.0.9
SparkleUpdateInfoProvider: Found URL https://reinventedsoftware.com/feeder/downloads/Feeder_4.0.9.dmg
{'Output': {'url': 'https://reinventedsoftware.com/feeder/downloads/Feeder_4.0.9.dmg',
            'version': '4.0.9'}}
URLDownloader
{'Input': {'filename': 'Feeder 4-4.0.9.dmg',
           'url': 'https://reinventedsoftware.com/feeder/downloads/Feeder_4.0.9.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Feeder4/downloads/Feeder 4-4.0.9.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Feeder4/downloads/Feeder '
                        '4-4.0.9.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Feeder4/receipts/Feeder4.pkg-receipt-20210213-205607.plist

Nothing downloaded, packaged or imported.
```

## ✅ Reinvented/Together.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Reinvented/Together.pkg.recipe
Processing repos/homebysix-recipes/Reinvented/Together.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://reinventedsoftware.com/together/downloads/Together3.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 7930
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.8.8
SparkleUpdateInfoProvider: Found URL https://reinventedsoftware.com/together/downloads/Together_3.8.8.dmg
{'Output': {'url': 'https://reinventedsoftware.com/together/downloads/Together_3.8.8.dmg',
            'version': '3.8.8'}}
URLDownloader
{'Input': {'filename': 'Together 3-3.8.8.dmg',
           'url': 'https://reinventedsoftware.com/together/downloads/Together_3.8.8.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Together3/downloads/Together 3-3.8.8.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Together3/downloads/Together '
                        '3-3.8.8.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Together3/receipts/Together.pkg-receipt-20210213-205609.plist

Nothing downloaded, packaged or imported.
```

## ✅ Revisions/Revisions.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Revisions/Revisions.pkg.recipe
Processing repos/homebysix-recipes/Revisions/Revisions.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '<h5>((\\d+)\\.(\\d+)(\\.(\\d+))?)</h5>',
           'result_output_var_name': 'version',
           'url': 'https://www.revisionsapp.com/releases'}}
URLTextSearcher: Found matching text (version): 3.0.1
{'Output': {'version': '3.0.1'}}
URLDownloader
{'Input': {'url': 'https://www.revisionsapp.com/downloads/revisions-3.0.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Revisions/downloads/revisions-3.0.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Revisions/downloads/revisions-3.0.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Revisions/receipts/Revisions.pkg-receipt-20210213-205609.plist

Nothing downloaded, packaged or imported.
```

## ✅ Royal/RoyalTSX.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Royal/RoyalTSX.pkg.recipe
Processing repos/homebysix-recipes/Royal/RoyalTSX.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'https://royaltsx-v4.royalapps.com/updates/royaltsx_.+\\.dmg',
           'result_output_var_name': 'url',
           'url': 'https://www.royalapps.com/ts/mac/download'}}
URLTextSearcher: Found matching text (url): https://royaltsx-v4.royalapps.com/updates/royaltsx_4.3.6.1000.dmg
{'Output': {'url': 'https://royaltsx-v4.royalapps.com/updates/royaltsx_4.3.6.1000.dmg'}}
URLDownloader
{'Input': {'url': 'https://royaltsx-v4.royalapps.com/updates/royaltsx_4.3.6.1000.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.RoyalTSX/downloads/royaltsx_4.3.6.1000.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.RoyalTSX/downloads/royaltsx_4.3.6.1000.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.RoyalTSX/receipts/RoyalTSX.pkg-receipt-20210213-205611.plist

Nothing downloaded, packaged or imported.
```

## ✅ Sblack/Sblack.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Sblack/Sblack.pkg.recipe
Processing repos/homebysix-recipes/Sblack/Sblack.pkg.recipe...
URLDownloader
{'Input': {'url': 'https://boxyteam-static.s3.amazonaws.com/release/Sblack.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Sblack/downloads/Sblack.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Sblack/downloads/Sblack.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Sblack/receipts/Sblack.pkg-receipt-20210213-205612.plist

Nothing downloaded, packaged or imported.
```

## ✅ Scherlokk/Scherlokk.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Scherlokk/Scherlokk.pkg.recipe
Processing repos/homebysix-recipes/Scherlokk/Scherlokk.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Scherlokk.dmg',
           'url': 'https://naarakstudio.com/download/Scherlokk.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Scherlokk/downloads/Scherlokk.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Scherlokk/downloads/Scherlokk.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Scherlokk/receipts/Scherlokk.pkg-receipt-20210213-205614.plist

Nothing downloaded, packaged or imported.
```

## ✅ ShareMouse/ShareMouse.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/ShareMouse/ShareMouse.pkg.recipe
Processing repos/homebysix-recipes/ShareMouse/ShareMouse.pkg.recipe...
URLDownloader
{'Input': {'filename': 'ShareMouse.dmg',
           'url': 'http://www.keyboard-and-mouse-sharing.com/ShareMouseSetup.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ShareMouse/downloads/ShareMouse.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ShareMouse/downloads/ShareMouse.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.ShareMouse/receipts/ShareMouse.pkg-receipt-20210213-205616.plist

Nothing downloaded, packaged or imported.
```

## ✅ Skim/Skim.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Skim/Skim.pkg.recipe
Processing repos/homebysix-recipes/Skim/Skim.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://skim-app.sourceforge.io/skim.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 130
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.6
SparkleUpdateInfoProvider: Found URL https://sourceforge.net/projects/skim-app/files/Skim/Skim-1.6/Skim-1.6.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/skim-app/files/Skim/Skim-1.6/Skim-1.6.dmg/download',
            'version': '1.6'}}
URLDownloader
{'Input': {'filename': 'Skim-1.6.dmg',
           'url': 'https://sourceforge.net/projects/skim-app/files/Skim/Skim-1.6/Skim-1.6.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Skim/downloads/Skim-1.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Skim/downloads/Skim-1.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Skim/receipts/Skim.pkg-receipt-20210213-205617.plist

Nothing downloaded, packaged or imported.
```

## ✅ SnapGene/SnapGeneViewer.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/SnapGene/SnapGeneViewer.pkg.recipe
Processing repos/homebysix-recipes/SnapGene/SnapGeneViewer.pkg.recipe...
URLDownloader
{'Input': {'filename': 'SnapGene Viewer.dmg',
           'url': 'https://www.snapgene.com/local/targets/viewer_download.php?os=mac&majorRelease=latest&minorRelease=latest'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SnapGeneViewer/downloads/SnapGene Viewer.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SnapGeneViewer/downloads/SnapGene '
                        'Viewer.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SnapGeneViewer/receipts/SnapGeneViewer.pkg-receipt-20210213-205619.plist

Nothing downloaded, packaged or imported.
```

## ✅ SpiderOak/SpiderOakONE.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/SpiderOak/SpiderOakONE.pkg.recipe
Processing repos/homebysix-recipes/SpiderOak/SpiderOakONE.pkg.recipe...
URLDownloader
{'Input': {'filename': 'SpiderOakONE.dmg',
           'url': 'https://spideroak.com/getbuild?platform=mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SpiderOakONE/downloads/SpiderOakONE.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SpiderOakONE/downloads/SpiderOakONE.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SpiderOakONE/receipts/SpiderOakONE.pkg-receipt-20210213-205620.plist

Nothing downloaded, packaged or imported.
```

## ✅ Sublime HQ/Sublime Merge.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Sublime\ HQ/Sublime\ Merge.pkg.recipe
Processing repos/homebysix-recipes/Sublime HQ/Sublime Merge.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="https:\\/\\/download\\.sublimetext\\.com\\/sublime_merge_build_(\\d+)_mac\\.zip">',
           'result_output_var_name': 'version',
           'url': 'https://www.sublimemerge.com'}}
URLTextSearcher: Found matching text (version): 2039
{'Output': {'version': '2039'}}
URLDownloader
{'Input': {'filename': 'Sublime Merge-2039.zip',
           'url': 'https://download.sublimetext.com/sublime_merge_build_2039_mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SublimeMerge/downloads/Sublime Merge-2039.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SublimeMerge/downloads/Sublime '
                        'Merge-2039.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SublimeMerge/receipts/Sublime Merge.pkg-receipt-20210213-205622.plist

Nothing downloaded, packaged or imported.
```

## ✅ SugarSync/SugarSync.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/SugarSync/SugarSync.pkg.recipe
Processing repos/homebysix-recipes/SugarSync/SugarSync.pkg.recipe...
URLDownloader
{'Input': {'filename': 'SugarSync.dmg',
           'url': 'https://www.sugarsync.com/downloads/InstallSugarSync.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SugarSync/downloads/SugarSync.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SugarSync/downloads/SugarSync.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.SugarSync/receipts/SugarSync.pkg-receipt-20210213-205623.plist

Nothing downloaded, packaged or imported.
```

## ✅ SuperMegaUltraGroovy/FuzzMeasure.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/SuperMegaUltraGroovy/FuzzMeasure.pkg.recipe
Processing repos/homebysix-recipes/SuperMegaUltraGroovy/FuzzMeasure.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https:\\/\\/downloads\\.rodetest\\.com\\/fuzzmeasure\\/FuzzMeasure-[\\d\\.]+\\.zip)">',
           'result_output_var_name': 'url',
           'url': 'https://www.rodetest.com/download'}}
URLTextSearcher: Found matching text (url): https://downloads.rodetest.com/fuzzmeasure/FuzzMeasure-39.zip
{'Output': {'url': 'https://downloads.rodetest.com/fuzzmeasure/FuzzMeasure-39.zip'}}
URLDownloader
{'Input': {'filename': 'FuzzMeasure.zip',
           'url': 'https://downloads.rodetest.com/fuzzmeasure/FuzzMeasure-39.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FuzzMeasure/downloads/FuzzMeasure.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FuzzMeasure/downloads/FuzzMeasure.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.FuzzMeasure/receipts/FuzzMeasure.pkg-receipt-20210213-205625.plist

Nothing downloaded, packaged or imported.
```

## ✅ TMNotifier/TMNotifier.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/TMNotifier/TMNotifier.pkg.recipe
Processing repos/homebysix-recipes/TMNotifier/TMNotifier.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://tmnotifier.com/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 31
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.0.7
SparkleUpdateInfoProvider: Found URL https://tmnotifier.com/downloads/TMNotifier_1.0.7.dmg
{'Output': {'url': 'https://tmnotifier.com/downloads/TMNotifier_1.0.7.dmg',
            'version': '1.0.7'}}
URLDownloader
{'Input': {'filename': 'TMNotifier-1.0.7.dmg',
           'url': 'https://tmnotifier.com/downloads/TMNotifier_1.0.7.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TMNotifier/downloads/TMNotifier-1.0.7.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TMNotifier/downloads/TMNotifier-1.0.7.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TMNotifier/receipts/TMNotifier.pkg-receipt-20210213-205626.plist

Nothing downloaded, packaged or imported.
```

## ✅ TermHere/TermHere.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/TermHere/TermHere.pkg.recipe
Processing repos/homebysix-recipes/TermHere/TermHere.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'TermHere%20([\\d\\.]+)\\.dmg',
           'result_output_var_name': 'version',
           'url': 'https://hbang.ws/apps/termhere/'}}
URLTextSearcher: Found matching text (version): 1.2.1
{'Output': {'version': '1.2.1'}}
URLDownloader
{'Input': {'filename': 'TermHere-1.2.1.dmg',
           'url': 'https://cdn.hbang.ws/dl/macos/TermHere%201.2.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TermHere/downloads/TermHere-1.2.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TermHere/downloads/TermHere-1.2.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TermHere/receipts/TermHere.pkg-receipt-20210213-205628.plist

Nothing downloaded, packaged or imported.
```

## ✅ Thyme/Thyme.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Thyme/Thyme.pkg.recipe
Processing repos/homebysix-recipes/Thyme/Thyme.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'joaomoreno/thyme'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'Thyme.0.5.1.dmg' from release 'Thyme 0.5.1'
{'Output': {'release_notes': '**Fixed**: Pause on sleep resumes even if not '
                             'paused #28\n',
            'url': 'https://github.com/joaomoreno/thyme/releases/download/0.5.1/Thyme.0.5.1.dmg',
            'version': '0.5.1'}}
URLDownloader
{'Input': {'filename': 'Thyme-0.5.1.dmg',
           'url': 'https://github.com/joaomoreno/thyme/releases/download/0.5.1/Thyme.0.5.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Thyme/downloads/Thyme-0.5.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Thyme/downloads/Thyme-0.5.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Thyme/receipts/Thyme.pkg-receipt-20210213-205629.plist

Nothing downloaded, packaged or imported.
```

## ✅ Toggl/TogglDesktop.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Toggl/TogglDesktop.pkg.recipe
Processing repos/homebysix-recipes/Toggl/TogglDesktop.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '"(?P<url>https:\\/\\/github\\.com\\/toggl-open-source\\/toggldesktop\\/releases\\/download\\/v(?P<version>[\\d\\.]+)\\/TogglDesktop-.+\\.dmg)"',
           'url': 'https://toggl-open-source.github.io/toggldesktop/download/macos-stable/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://github.com/toggl-open-source/toggldesktop/releases/download/v7.5.441/TogglDesktop-7_5_441.dmg
URLTextSearcher: Found matching text (version): 7.5.441
URLTextSearcher: Found matching text (match): https://github.com/toggl-open-source/toggldesktop/releases/download/v7.5.441/TogglDesktop-7_5_441.dmg
{'Output': {'match': 'https://github.com/toggl-open-source/toggldesktop/releases/download/v7.5.441/TogglDesktop-7_5_441.dmg',
            'url': 'https://github.com/toggl-open-source/toggldesktop/releases/download/v7.5.441/TogglDesktop-7_5_441.dmg',
            'version': '7.5.441'}}
URLDownloader
{'Input': {'filename': 'TogglDesktop-7.5.441.dmg',
           'url': 'https://github.com/toggl-open-source/toggldesktop/releases/download/v7.5.441/TogglDesktop-7_5_441.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TogglDesktop/downloads/TogglDesktop-7.5.441.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TogglDesktop/downloads/TogglDesktop-7.5.441.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TogglDesktop/receipts/TogglDesktop.pkg-receipt-20210213-205630.plist

Nothing downloaded, packaged or imported.
```

## ✅ TouchSwitcher/TouchSwitcher.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/TouchSwitcher/TouchSwitcher.pkg.recipe
Processing repos/homebysix-recipes/TouchSwitcher/TouchSwitcher.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://hazeover.com/touchswitcher/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 135
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.4.1
SparkleUpdateInfoProvider: Found URL https://hazeover.com/touchswitcher/TouchSwitcher.txz
{'Output': {'url': 'https://hazeover.com/touchswitcher/TouchSwitcher.txz',
            'version': '1.4.1'}}
URLDownloader
{'Input': {'filename': 'TouchSwitcher-1.4.1.tar.bz2',
           'url': 'https://hazeover.com/touchswitcher/TouchSwitcher.txz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TouchSwitcher/downloads/TouchSwitcher-1.4.1.tar.bz2
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TouchSwitcher/downloads/TouchSwitcher-1.4.1.tar.bz2'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.TouchSwitcher/receipts/TouchSwitcher.pkg-receipt-20210213-205632.plist

Nothing downloaded, packaged or imported.
```

## ✅ Tunabelly/DiskDiet.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Tunabelly/DiskDiet.pkg.recipe
Processing repos/homebysix-recipes/Tunabelly/DiskDiet.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.tunabellysoftware.com/resources/sparkle/diskdiet.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1166
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 5.4.10
SparkleUpdateInfoProvider: Found URL https://tunabellysoftware.com/resources/Disk%2520Diet%25205.4.10.dmg
{'Output': {'url': 'https://tunabellysoftware.com/resources/Disk%2520Diet%25205.4.10.dmg',
            'version': '5.4.10'}}
URLDownloader
{'Input': {'filename': 'Disk Diet-5.4.10.dmg',
           'url': 'https://tunabellysoftware.com/resources/Disk%2520Diet%25205.4.10.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DiskDiet/downloads/Disk Diet-5.4.10.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DiskDiet/downloads/Disk '
                        'Diet-5.4.10.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.DiskDiet/receipts/DiskDiet.pkg-receipt-20210213-205633.plist

Nothing downloaded, packaged or imported.
```

## ✅ Vadim Shpakovski/NativeConnect.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Vadim\ Shpakovski/NativeConnect.pkg.recipe
Processing repos/homebysix-recipes/Vadim Shpakovski/NativeConnect.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '"id":(\\d+),',
           'result_output_var_name': 'release_id',
           'url': 'https://install.appcenter.ms/api/v0.1/apps/vadim.shpakovski/nativeconnect/distribution_groups/public/public_releases'}}
URLTextSearcher: Found matching text (release_id): 237
{'Output': {'release_id': '237'}}
URLTextSearcher
{'Input': {'re_pattern': '"download_url":"(https:\\/\\/.+\\.app\\.zip\\?.+)","install_url":',
           'result_output_var_name': 'url',
           'url': 'https://install.appcenter.ms/api/v0.1/apps/vadim.shpakovski/nativeconnect/distribution_groups/public/releases/237'}}
URLTextSearcher: Found matching text (url): https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=swklB28MtjAhI3Ej%2Bx7S93M3VDWjkvZXSTQ%2FEKmfJac%3D&se=2021-02-15T00%3A11%3A00Z&sp=r
{'Output': {'url': 'https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=swklB28MtjAhI3Ej%2Bx7S93M3VDWjkvZXSTQ%2FEKmfJac%3D&se=2021-02-15T00%3A11%3A00Z&sp=r'}}
URLDownloader
{'Input': {'filename': 'NativeConnect.zip',
           'url': 'https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=swklB28MtjAhI3Ej%2Bx7S93M3VDWjkvZXSTQ%2FEKmfJac%3D&se=2021-02-15T00%3A11%3A00Z&sp=r'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NativeConnect/downloads/NativeConnect.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NativeConnect/downloads/NativeConnect.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.NativeConnect/receipts/NativeConnect.pkg-receipt-20210213-205639.plist

Nothing downloaded, packaged or imported.
```

## ✅ Vanilla/Vanilla.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Vanilla/Vanilla.pkg.recipe
Processing repos/homebysix-recipes/Vanilla/Vanilla.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://updates.devmate.com/net.matthewpalmer.Vanilla.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 33
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.1.3
SparkleUpdateInfoProvider: Found URL https://dl.devmate.com/net.matthewpalmer.Vanilla/33/1567125972/Vanilla-33.zip
{'Output': {'url': 'https://dl.devmate.com/net.matthewpalmer.Vanilla/33/1567125972/Vanilla-33.zip',
            'version': '1.1.3'}}
URLDownloader
{'Input': {'filename': 'Vanilla-1.1.3.zip',
           'url': 'https://dl.devmate.com/net.matthewpalmer.Vanilla/33/1567125972/Vanilla-33.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Vanilla/downloads/Vanilla-1.1.3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Vanilla/downloads/Vanilla-1.1.3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Vanilla/receipts/Vanilla.pkg-receipt-20210213-205640.plist

Nothing downloaded, packaged or imported.
```

## ✅ VyprVPN/VyprVPN.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/VyprVPN/VyprVPN.pkg.recipe
Processing repos/homebysix-recipes/VyprVPN/VyprVPN.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'desktop/mac/production/([\\d\\.]+)/VyprVPN',
           'result_output_var_name': 'version',
           'url': 'https://www.vyprvpn.com/vpn-apps/vpn-for-mac'}}
URLTextSearcher: Found matching text (version): 4.1.1.9013
{'Output': {'version': '4.1.1.9013'}}
URLDownloader
{'Input': {'filename': 'VyprVPN-4.1.1.9013.dmg',
           'url': 'https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/4.1.1.9013/VyprVPN_v4.1.1.9013.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.VyprVPN/downloads/VyprVPN-4.1.1.9013.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.VyprVPN/downloads/VyprVPN-4.1.1.9013.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.VyprVPN/receipts/VyprVPN.pkg-receipt-20210213-205642.plist

Nothing downloaded, packaged or imported.
```

## ✅ Waltr/Waltr.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Waltr/Waltr.pkg.recipe
Processing repos/homebysix-recipes/Waltr/Waltr.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Waltr.dmg',
           'url': 'https://dl.devmate.com/com.softorino.Waltr/WALTR.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Waltr/downloads/Waltr.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Waltr/downloads/Waltr.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Waltr/receipts/Waltr.pkg-receipt-20210213-205642.plist

Nothing downloaded, packaged or imported.
```

## ✅ Warewolf/Espresso.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/Warewolf/Espresso.pkg.recipe
Processing repos/homebysix-recipes/Warewolf/Espresso.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://espressoapp.com/updates/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 52102121
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 5.6
SparkleUpdateInfoProvider: Found URL https://downloads.kangacode.com/Espresso/Espresso_5.6.zip
{'Output': {'url': 'https://downloads.kangacode.com/Espresso/Espresso_5.6.zip',
            'version': '5.6'}}
URLDownloader
{'Input': {'filename': 'Espresso-5.6.zip',
           'url': 'https://downloads.kangacode.com/Espresso/Espresso_5.6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Espresso/downloads/Espresso-5.6.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Espresso/downloads/Espresso-5.6.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Espresso/receipts/Espresso.pkg-receipt-20210213-205645.plist

Nothing downloaded, packaged or imported.
```

## ✅ WhatSize/WhatSize.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/WhatSize/WhatSize.pkg.recipe
Processing repos/homebysix-recipes/WhatSize/WhatSize.pkg.recipe...
URLDownloader
{'Input': {'filename': 'WhatSize.dmg',
           'url': 'https://whatsizemac.com/software/whatsize6/whatsize.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.WhatSize/downloads/WhatSize.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.WhatSize/downloads/WhatSize.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.WhatSize/receipts/WhatSize.pkg-receipt-20210213-205647.plist

Nothing downloaded, packaged or imported.
```

## ✅ YellowMug/EasyBatchPhoto.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/YellowMug/EasyBatchPhoto.pkg.recipe
Processing repos/homebysix-recipes/YellowMug/EasyBatchPhoto.pkg.recipe...
URLDownloader
{'Input': {'filename': 'EasyBatchPhoto.dmg',
           'url': 'https://www.yellowmug.com/download/EasyBatchPhoto.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.EasyBatchPhoto/downloads/EasyBatchPhoto.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.EasyBatchPhoto/downloads/EasyBatchPhoto.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.EasyBatchPhoto/receipts/EasyBatchPhoto.pkg-receipt-20210213-205647.plist

Nothing downloaded, packaged or imported.
```

## ✅ YellowMug/YemuZip.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/YellowMug/YemuZip.pkg.recipe
Processing repos/homebysix-recipes/YellowMug/YemuZip.pkg.recipe...
URLDownloader
{'Input': {'url': 'https://www.yellowmug.com/download/YemuZip.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.YemuZip/downloads/YemuZip.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.YemuZip/downloads/YemuZip.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.YemuZip/receipts/YemuZip.pkg-receipt-20210213-205648.plist

Nothing downloaded, packaged or imported.
```

## ✅ coconutBattery/coconutBattery.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/coconutBattery/coconutBattery.pkg.recipe
Processing repos/homebysix-recipes/coconutBattery/coconutBattery.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://coconut-flavour.com/updates/coconutBattery.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3.9.4
SparkleUpdateInfoProvider: Found URL https://www.coconut-flavour.com/downloads/coconutBattery_394_af177845.zip
{'Output': {'url': 'https://www.coconut-flavour.com/downloads/coconutBattery_394_af177845.zip',
            'version': '3.9.4'}}
URLDownloader
{'Input': {'filename': 'coconutBattery-3.9.4.zip',
           'url': 'https://www.coconut-flavour.com/downloads/coconutBattery_394_af177845.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.coconutBattery/downloads/coconutBattery-3.9.4.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.coconutBattery/downloads/coconutBattery-3.9.4.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.coconutBattery/receipts/coconutBattery.pkg-receipt-20210213-205651.plist

Nothing downloaded, packaged or imported.
```

## ✅ iStumbler/iStumbler.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/iStumbler/iStumbler.pkg.recipe
Processing repos/homebysix-recipes/iStumbler/iStumbler.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://istumbler.net/feeds/appcast.rss'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 103.43
SparkleUpdateInfoProvider: Found URL https://istumbler.net/downloads/istumbler-103.43.dmg
{'Output': {'url': 'https://istumbler.net/downloads/istumbler-103.43.dmg',
            'version': '103.43'}}
URLDownloader
{'Input': {'filename': 'iStumbler-103.43.dmg',
           'url': 'https://istumbler.net/downloads/istumbler-103.43.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.iStumbler/downloads/iStumbler-103.43.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.iStumbler/downloads/iStumbler-103.43.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.iStumbler/receipts/iStumbler.pkg-receipt-20210213-205652.plist

Nothing downloaded, packaged or imported.
```

## ✅ iZip/iZip.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/iZip/iZip.pkg.recipe
Processing repos/homebysix-recipes/iZip/iZip.pkg.recipe...
URLDownloader
{'Input': {'filename': 'iZip.dmg', 'url': 'https://www.izip.com/izip.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.iZip/downloads/iZip.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.iZip/downloads/iZip.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.iZip/receipts/iZip.pkg-receipt-20210213-205653.plist

Nothing downloaded, packaged or imported.
```

## ✅ miXscope/miXscope.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/homebysix-recipes/miXscope/miXscope.pkg.recipe
Processing repos/homebysix-recipes/miXscope/miXscope.pkg.recipe...
URLDownloader
{'Input': {'filename': 'miXscope.dmg',
           'url': 'http://www.edhsw.com/mixscope/miXscope.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.miXscope/downloads/miXscope.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.miXscope/downloads/miXscope.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.miXscope/receipts/miXscope.pkg-receipt-20210213-205654.plist

Nothing downloaded, packaged or imported.
```

