### PR TITLE
Add additional MunkiPkginfoMerger

### DIFF
--- a/Zoom/Zoom.munki.recipe
+++ b/Zoom/Zoom.munki.recipe
@@ -64,6 +64,20 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>minimum_os_version</key>
+					<string>%min_os_version%</string>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>version_comparison_key</key>


### PR DESCRIPTION
To merge collected version and min_os_version from zoom pkg recipe

Builds on changes from #379 