### PR TITLE
Update RingCentralMeetings.download.recipe

### DIFF
--- a/RingCentral/RingCentralMeetings.download.recipe
+++ b/RingCentral/RingCentralMeetings.download.recipe
@@ -23,7 +23,7 @@
 				<key>result_output_var_name</key>
 				<string>download_path</string>
 				<key>url</key>
-				<string>https://www.ringcentral.com/office/features/online-meetings/video-conferencing.html</string>
+				<string>https://www.ringcentral.com/apps/rc-meetings</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
Download page URL no longer provides a link to the pkg - updated with a new URL which does. :-)