### PR TITLE
Bump Acorn version to 7 in code signature

### DIFF
--- a/FlyingMeat/Acorn.download.recipe
+++ b/FlyingMeat/Acorn.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Acorn.app</string>
 				<key>requirement</key>
-				<string>identifier "com.flyingmeat.Acorn6" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WZCN9HJ4VP</string>
+				<string>identifier "com.flyingmeat.Acorn7" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WZCN9HJ4VP</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Acorn just reached version 7, so the identifier in the code signature now shows `Acorn7`. 