### PR TITLE
added PLATFORM_ARCH input variable

### DIFF
--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9, 10, 11, 12, 13, and 14.
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9 through 16.
+
+To download the Intel or Apple Silicon build for version 16, set PLATFORM_ARCH in your override to intel or m1.
 
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>
@@ -14,6 +16,8 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 		<string>15</string>
 		<key>NAME</key>
 		<string>Parallels Desktop</string>
+		<key>PLATFORM_ARCH</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,7 +29,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 				<key>filename</key>
 				<string>%NAME%-%MAJOR_VERSION%.dmg</string>
 				<key>url</key>
-				<string>https://www.parallels.com/directdownload/pd%MAJOR_VERSION%</string>
+				<string>https://www.parallels.com/directdownload/pd%MAJOR_VERSION%/%PLATFORM_ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Parallels/ParallelsDesktop.install.recipe
+++ b/Parallels/ParallelsDesktop.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Installs the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9, 10, 11, 12, 13, and 14.</string>
+	<string>Installs the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9 through 15.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.install.recipe
+++ b/Parallels/ParallelsDesktop.install.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.install.ParallelsDesktop</string>
 	<key>Input</key>
 	<dict>
-		<key>MAJOR_VERSION</key>
-		<string>14</string>
 		<key>NAME</key>
 		<string>Parallels Desktop</string>
 	</dict>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Parallels Desktop and imports it into Munki. This recipe has been tested with major versions 9, 10, 11, 12, 13, and 14.</string>
+	<string>Downloads the latest version of Parallels Desktop and imports it into Munki. This recipe has been tested with major versions 9 through 15.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.homebysix.munki.ParallelsDesktop</string>
 	<key>Input</key>
 	<dict>
-		<key>MAJOR_VERSION</key>
-		<string>14</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>

--- a/Parallels/ParallelsDesktop.pkg.recipe
+++ b/Parallels/ParallelsDesktop.pkg.recipe
@@ -3,15 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Parallels Desktop and creates a package. This recipe has been tested with major versions 9, 10, 11, 12, 13, and 14.</string>
+	<string>Downloads the latest version of Parallels Desktop and creates a package. This recipe has been tested with major versions 9 through 15.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.ParallelsDesktop</string>
 	<key>Input</key>
 	<dict>
 		<key>BUNDLE_ID</key>
 		<string>com.parallels.desktop.installer</string>
-		<key>MAJOR_VERSION</key>
-		<string>14</string>
 		<key>NAME</key>
 		<string>Parallels Desktop</string>
 	</dict>


### PR DESCRIPTION
- added `PLATFORM_ARCH` input variable (need to specify `intel` or `m1` for version 16) #405
- updated `URLDownloader` to point at `PLATFORM_ARCH` subdirectory (if specified)
- removed `MAJOR_VERSION` input variables from child recipes