### PR TITLE
Update Parallels descriptions: only v16 supports arch

### DIFF
--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -5,7 +5,9 @@
 	<key>Description</key>
 	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9 through 16.
 
-To download the Intel or Apple Silicon build for version 16, set PLATFORM_ARCH in your override to intel or m1.
+For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+
+For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
 
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>

--- a/Parallels/ParallelsDesktop.install.recipe
+++ b/Parallels/ParallelsDesktop.install.recipe
@@ -3,7 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Installs the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9 through 15.</string>
+	<string>Installs the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9 through 16.
+
+For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+
+For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
+
+This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -3,7 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Parallels Desktop and imports it into Munki. This recipe has been tested with major versions 9 through 15.</string>
+	<string>Downloads the latest version of Parallels Desktop and imports it into Munki. This recipe has been tested with major versions 9 through 16.
+
+For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+
+For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture. Create multiple overrides if you wish to offer both flavors via Munki.
+
+This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.pkg.recipe
+++ b/Parallels/ParallelsDesktop.pkg.recipe
@@ -3,7 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Parallels Desktop and creates a package. This recipe has been tested with major versions 9 through 15.</string>
+	<string>Downloads the latest version of Parallels Desktop and creates a package. This recipe has been tested with major versions 9 through 16.
+
+For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+
+For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
+
+This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.ParallelsDesktop</string>
 	<key>Input</key>


### PR DESCRIPTION
Parallels recipe with major version 15 doesn't work if you specify `PLATFORM_ARCH`, and major version 16 doesn't work if you *omit* `PLATFORM_ARCH`.