### PR TITLE
Replace Versioner with PlistReader in BetterTouchTool.download.recipe

### DIFF
--- a/BetterTouchTool/BetterTouchTool.download.recipe
+++ b/BetterTouchTool/BetterTouchTool.download.recipe
@@ -59,13 +59,18 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
+				<key>info_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/BetterTouchTool.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleShortVersionString</key>
+					<string>version</string>
+					<key>LSMinimumSystemVersion</key>
+					<string>min_os_version</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>Versioner</string>
+			<string>PlistReader</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
For use of LSMinimumSystemVersion in downstream recipes.  munki recipe import will do this automatically, but would be useful data to get for other recipes