### PR TITLE
Update AudioHijack.download download URL

### DIFF
--- a/RogueAmoeba/AudioHijack.download.recipe
+++ b/RogueAmoeba/AudioHijack.download.recipe
@@ -23,7 +23,7 @@
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>https://d2oxtzozd38ts8.cloudfront.net/audiohijack/download/AudioHijack.zip</string>
+				<string>https://rogueamoeba.com/audiohijack/download/AudioHijack.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Client apps were seeing an update available via their built-in mechanism where AutoPkg was not due to the cloudfront URL not having the current version available.  There is a direct download link on the Rogue Amoeba site that pulled the correct, latest version when testing locally.