### PR TITLE
Update AudioHijack.munki to include ACE install

### DIFF
--- a/RogueAmoeba/AudioHijack.munki.recipe
+++ b/RogueAmoeba/AudioHijack.munki.recipe
@@ -30,9 +30,9 @@
 			<string>%NAME%</string>
 			<key>postinstall_script</key>
 			<string>#!/bin/bash
-if [[ -f /Applications/Audio\ Hijack.app/Contents/Resources/aceinstaller ]]
-then
-	/Applications/Audio\ Hijack.app/Contents/Resources/aceinstaller install -s
+# Install ACE driver audio plugin
+if [[ -x "/Applications/Audio Hijack.app/Contents/Resources/aceinstaller" ]]; then
+    "/Applications/Audio Hijack.app/Contents/Resources/aceinstaller" install -s
 fi
 </string>
 			<key>unattended_install</key>

--- a/RogueAmoeba/AudioHijack.munki.recipe
+++ b/RogueAmoeba/AudioHijack.munki.recipe
@@ -28,6 +28,13 @@
 			<string>Audio Hijack</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/bash
+if [[ -f /Applications/Audio\ Hijack.app/Contents/Resources/aceinstaller ]]
+then
+	/Applications/Audio\ Hijack.app/Contents/Resources/aceinstaller install -s
+fi
+</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/RogueAmoeba/AudioHijack.pkg.recipe
+++ b/RogueAmoeba/AudioHijack.pkg.recipe
@@ -47,6 +47,8 @@
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 					<key>version</key>
 					<string>%version%</string>
+					<key>scripts</key>
+					<string>AudioHijackScripts</string>
 				</dict>
 			</dict>
 			<key>Processor</key>

--- a/RogueAmoeba/AudioHijackScripts/postinstall
+++ b/RogueAmoeba/AudioHijackScripts/postinstall
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Install ACE driver audio plugin
+if [[ -x "$3/Applications/Audio Hijack.app/Contents/Resources/aceinstaller" ]]; then
+    "$3/Applications/Audio Hijack.app/Contents/Resources/aceinstaller" install -s
+fi


### PR DESCRIPTION
Audio Hijack requires the Rogue Amoeba ACE.driver Audio plugin. If it is not installed or current on launch, the user is presented with a GUI to install it - requiring admin rights.

There is a compiled binary at `Audio Hijack.app/Contents/Resources/aceinstaller`. The usage for that binary is:

```
aceinstaller: <action>
    help
        Display this message.
    install [-s|--silent]
        Install (or update) the ACE.driver coreaudiod plugin. The version to be installed must be
        newer than what is currently installed, and the current system version must be supported.
        Installing requires root privileges.
        -s|--silent    Do not generate an error if the version to be installed is not newer than
                       than the version that is currently installed.
    uninstall [-s|--silent]
        Uninstall the ACE.driver coreaudiod plugin. There must be a plugin installed for it to be
        uninstalled. Uninstalling requires root privileges.
    version
        Display the installed and installable ACE versions.
```

I've tested using the command `aceinstaller install -s` in a pkginfo postinstall script on 10.14-11.2.3 and all installed the latest version.
When updating Audio Hijack from 3.8.3 to 3.8.4, there was a GUI prompt that said the ACE driver needed to be updated, so this postinstall_script should run every time Audio Hijack is installed to make sure it is using the latest, current ACE.driver.