### PR TITLE
Add FindAndReplace to handle quoted enclosure URL in Sparkle feed

### DIFF
--- a/ViennaRSS/Vienna.download.recipe
+++ b/ViennaRSS/Vienna.download.recipe
@@ -33,8 +33,23 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>find</key>
+				<string>%252F</string>
+				<key>input_string</key>
+				<string>%url%</string>
+				<key>replace</key>
+				<string>/</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.tgz</string>
+				<key>url</key>
+				<string>%output_string%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Resolves #425.