### PR TITLE
Updated Eclipse recipes

### DIFF
--- a/Eclipse/Eclipse.download.recipe
+++ b/Eclipse/Eclipse.download.recipe
@@ -86,6 +86,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/*.app</string>
+				<key>requirement</key>
+				<string>identifier "org.eclipse.platform.ide" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JCDTMS22B4</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Eclipse/Eclipse.munki.recipe
+++ b/Eclipse/Eclipse.munki.recipe
@@ -37,18 +37,20 @@
 	<key>MinimumVersion</key>
 	<string>0.4.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.homebysix.pkg.Eclipse</string>
+	<string>com.github.homebysix.download.Eclipse</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
• added CodeSignatureVerifier to .download
• changed .munki to use .download as parent, as .munki can ingest the DMG as-is and will build an installs array based on the .app on disk.

```
{'Input': {'options': {'Eclipse IDE for Automotive Software Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-automotive[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for C/C++ Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-cpp[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Eclipse Committers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-committers[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-java[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java EE Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-jee[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java and DSL Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-dsl[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java and Report Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-reporting[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse Modeling Tools': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-modeling[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for PHP Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-php[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for Parallel Application Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-parallel[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for RCP and RAP Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-rcp[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for Scout Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-scout[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for Testers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-testing[\\w-]+macosx-cocoa-x86_64\\.dmg)'},
           'selection': 'Eclipse IDE for Java Developers'}}
OptionSelector: No value supplied for result_output_var_name, setting default value of: selection
OptionSelector: Selection 'Eclipse IDE for Java Developers': '\/downloads\/download\.php\?file=([/\w-]+eclipse-java[\w-]+macosx-cocoa-x86_64\.dmg)'
{'Output': {'selection': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-java[\\w-]+macosx-cocoa-x86_64\\.dmg)'}}
URLTextSearcher
{'Input': {'re_pattern': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-java[\\w-]+macosx-cocoa-x86_64\\.dmg)',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11) '
                                             'AppleWebKit/601.1.39 (KHTML, '
                                             'like Gecko) Version/9.0 '
                                             'Safari/601.1.39'},
           'result_output_var_name': 'match',
           'url': 'https://eclipse.org/downloads/eclipse-packages/'}}
URLTextSearcher: Found matching text (match): /technology/epp/downloads/release/2021-06/R/eclipse-java-2021-06-R-macosx-cocoa-x86_64.dmg
{'Output': {'match': '/technology/epp/downloads/release/2021-06/R/eclipse-java-2021-06-R-macosx-cocoa-x86_64.dmg'}}
URLDownloader
{'Input': {'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11) '
                                             'AppleWebKit/601.1.39 (KHTML, '
                                             'like Gecko) Version/9.0 '
                                             'Safari/601.1.39'},
           'url': 'https://eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2021-06/R/eclipse-java-2021-06-R-macosx-cocoa-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.homebysix.munki.Eclipse/downloads/eclipse-java-2021-06-R-macosx-cocoa-x86_64.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.homebysix.munki.Eclipse/downloads/eclipse-java-2021-06-R-macosx-cocoa-x86_64.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.homebysix.munki.Eclipse/downloads/eclipse-java-2021-06-R-macosx-cocoa-x86_64.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Developer',
                       'description': 'The essential tools for any Java '
                                      'developer, including a Java IDE, a CVS '
                                      'client, Git client, XML Editor, Mylyn, '
                                      'Maven integration...',
                       'developer': 'Eclipse Foundation',
                       'display_name': 'Eclipse IDE for Java Developers',
                       'name': 'Eclipse',
                       'unattended_install': True},
           'repo_subdirectory': 'developer'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/developer/Eclipse-4.20.0__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/developer/eclipse-java-2021-06-R-macosx-cocoa-x86_64-4.20.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Eclipse',
                                                       'pkg_repo_path': 'developer/eclipse-java-2021-06-R-macosx-cocoa-x86_64-4.20.0.dmg',
                                                       'pkginfo_path': 'developer/Eclipse-4.20.0__2.plist',
                                                       'version': '4.20.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date'                                         'creation_date': datetime.datetime(2021, 7, 6, 21, 22, 21),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Developer',
                           'description': 'The essential tools for any Java '
                                          'developer, including a Java IDE, a '
                                          'CVS client, Git client, XML Editor, '
                                          'Mylyn, Maven integration...',
                           'developer': 'Eclipse Foundation',
                           'display_name': 'Eclipse IDE for Java Developers',
                           'installer_item_hash': '4baf03af627b99d1840c3d08aaff6f2d3e4a679c8497e5b4597f7cb4403c3049',
                           'installer_item_location': 'developer/eclipse-java-2021-06-R-macosx-cocoa-x86_64-4.20.0.dmg',
                           'installer_item_size': 325693,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.eclipse.platform.ide',
                                         'CFBundleName': 'Eclipse',
                                         'CFBundleShortVersionString': '4.20.0',
                                         'CFBundleVersion': '4.20.0.I20210611-1600',
                                         'path': '/Applications/Eclipse.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Eclipse.app'}],
                           'minimum_os_version': '10.4.0',
                           'name': 'Eclipse',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '4.20.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/developer/eclipse-java-2021-06-R-macosx-cocoa-x86_64-4.20.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/developer/Eclipse-4.20.0__2.plist'}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.homebysix.munki.Eclipse/receipts/Eclipse.munki-receipt-20210706-222222.plist

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                       Pkg Repo Path                                                    Icon Repo Path
    ----     -------  --------  ------------                       -------------                                                    --------------
    Eclipse  4.20.0   testing   developer/Eclipse-4.20.0__2.plist  developer/eclipse-java-2021-06-R-macosx-cocoa-x86_64-4.20.0.dmg
```