### PR TITLE
Update Papers.download Regex to include 'x64'

### DIFF
--- a/Papers/Papers.download.recipe
+++ b/Papers/Papers.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>Papers_Setup_([\d\.]+)\.dmg</string>
+				<string>Papers_Setup_([\d\.]+)-x64\.dmg</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 				<key>url</key>
@@ -34,7 +34,7 @@
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>https://update.readcube.com/desktop/updates/Papers_Setup_%version%.dmg</string>
+				<string>https://update.readcube.com/desktop/updates/Papers_Setup_%version%-x64.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
It seems like the original download link have been changed to include x64 appended after the version number (see https://update.readcube.com/desktop/updates/latest-mac.yml)

I have modified the strings in the URLTextSearcher and URLDownloader accordingly.