### PR TITLE
fixed GoToMeetingURLProvider.py processor for Windows / Ubuntu

### DIFF
--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -31,6 +31,7 @@ HOSTNAME = "builds.cdn.getgo.com"
 if is_mac():
     import platform
     from distutils.version import LooseVersion
+
     # the following check is mac specific:
     if LooseVersion(platform.mac_ver()[0]) < LooseVersion("10.13.0"):
         # pylint: disable=no-member

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -23,16 +23,18 @@ import socket
 from distutils.version import LooseVersion
 
 # pylint: disable=unused-import
-from autopkglib import Processor, ProcessorError, URLGetter  # noqa: F401
+from autopkglib import Processor, ProcessorError, URLGetter, is_mac  # noqa: F401
 
 __all__ = ["GoToMeetingURLProvider"]
 
 HOSTNAME = "builds.cdn.getgo.com"
 
 # workaround for 10.12.x SNI issue
-if LooseVersion(platform.mac_ver()[0]) < LooseVersion("10.13.0"):
-    # pylint: disable=no-member
-    HOSTNAME = socket.gethostbyname_ex("builds.cdn.getgo.com")[0]
+if is_mac():
+    # the following check is mac specific:
+    if LooseVersion(platform.mac_ver()[0]) < LooseVersion("10.13.0"):
+        # pylint: disable=no-member
+        HOSTNAME = socket.gethostbyname_ex("builds.cdn.getgo.com")[0]
 
 BASE_URL = "https://" + HOSTNAME + "/g2mupdater/live/config.json"
 

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -18,9 +18,7 @@
 import gzip
 import json
 import os
-import platform
 import socket
-from distutils.version import LooseVersion
 
 # pylint: disable=unused-import
 from autopkglib import Processor, ProcessorError, URLGetter, is_mac  # noqa: F401
@@ -31,6 +29,8 @@ HOSTNAME = "builds.cdn.getgo.com"
 
 # workaround for 10.12.x SNI issue
 if is_mac():
+    import platform
+    from distutils.version import LooseVersion
     # the following check is mac specific:
     if LooseVersion(platform.mac_ver()[0]) < LooseVersion("10.13.0"):
         # pylint: disable=no-member


### PR DESCRIPTION
the `LooseVersion` check causes errors on Ubuntu in Docker and Windows. This makes this check only be preformed on macOS.

This PR addresses: https://github.com/autopkg/homebysix-recipes/issues/402

Without this fix, then this recipe only runs on macOS: https://github.com/jgstew/jgstew-recipes/blob/main/GoToMeeting/GoToMeeting-Win.download.recipe.yaml