### PR TITLE
version 17 url path change

### DIFF
--- a/Parallels/ParallelsDesktop.install.recipe
+++ b/Parallels/ParallelsDesktop.install.recipe
@@ -9,6 +9,8 @@ For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
 
 For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
 
+For major version 17, set the PLATFORM_ARCH in your override to "image"
+		
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.ParallelsDesktop</string>


### PR DESCRIPTION
Parallels 17 now has a universal binary, so the intel and m1 URLs do not appear to exist for v17. I was able to successfully use this for version 17 by setting the PLATFORM_ARCH to "image"