### PR TITLE
Switch to rogueamoeba.com for more reliably up-to-date downloads

### DIFF
--- a/RogueAmoeba/AirFoil.download.recipe
+++ b/RogueAmoeba/AirFoil.download.recipe
@@ -8,7 +8,7 @@
 NOTE: This recipe used to use the vendor's CloudFront CDN download URL
 (https://d2oxtzozd38ts8.cloudfront.net/airfoil/download/Airfoil.zip)
 however AutoPkg users found that CloudFront was sometimes not kept updated
-as new versions were releaesd. We are using the slower but more reliably
+as new versions were released. We are using the slower but more reliably
 updated rogueamoeba.com download link now.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.AirFoil</string>

--- a/RogueAmoeba/AudioHijack.download.recipe
+++ b/RogueAmoeba/AudioHijack.download.recipe
@@ -10,7 +10,7 @@
 NOTE: This recipe used to use the vendor's CloudFront CDN download URL
 (https://d2oxtzozd38ts8.cloudfront.net/audiohijack/download/AudioHijack.zip)
 however AutoPkg users found that CloudFront was sometimes not kept updated
-as new versions were releaesd. We are using the slower but more reliably
+as new versions were released. We are using the slower but more reliably
 updated rogueamoeba.com download link now.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.AudioHijack</string>

--- a/RogueAmoeba/Fission.download.recipe
+++ b/RogueAmoeba/Fission.download.recipe
@@ -10,7 +10,7 @@
 NOTE: This recipe used to use the vendor's CloudFront CDN download URL
 (https://d2oxtzozd38ts8.cloudfront.net/fission/download/Fission.zip)
 however AutoPkg users found that CloudFront was sometimes not kept updated
-as new versions were releaesd. We are using the slower but more reliably
+as new versions were released. We are using the slower but more reliably
 updated rogueamoeba.com download link now.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Fission</string>

--- a/RogueAmoeba/Nicecast.download.recipe
+++ b/RogueAmoeba/Nicecast.download.recipe
@@ -10,7 +10,7 @@
 NOTE: This recipe used to use the vendor's CloudFront CDN download URL
 (https://d2oxtzozd38ts8.cloudfront.net/nicecast/download/Nicecast.zip)
 however AutoPkg users found that CloudFront was sometimes not kept updated
-as new versions were releaesd. We are using the slower but more reliably
+as new versions were released. We are using the slower but more reliably
 updated rogueamoeba.com download link now.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Nicecast</string>

--- a/RogueAmoeba/Piezo.download.recipe
+++ b/RogueAmoeba/Piezo.download.recipe
@@ -10,7 +10,7 @@
 NOTE: This recipe used to use the vendor's CloudFront CDN download URL
 (https://d2oxtzozd38ts8.cloudfront.net/piezo/download/Piezo.zip)
 however AutoPkg users found that CloudFront was sometimes not kept updated
-as new versions were releaesd. We are using the slower but more reliably
+as new versions were released. We are using the slower but more reliably
 updated rogueamoeba.com download link now.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Piezo</string>


### PR DESCRIPTION
As noted in #422, Rogue Amoeba's CloudFront space is not always up to date with the latest downloads. In addition to Audio Hijack, the issue appears to be affecting Piezo and is likely to affect other products too.

```
# AutoPkg run with CloudFront download URL for Piezo
Versioner: Found version 1.7.3 in file ~/Library/AutoPkg/Cache/com.github.homebysix.download.Piezo/Piezo/Applications/Piezo.app/Contents/Info.plist

# AutoPkg run with rogueamoeba.com download URL for Piezo
Versioner: Found version 1.7.4 in file ~/Library/AutoPkg/Cache/com.github.homebysix.download.Piezo/Piezo/Applications/Piezo.app/Contents/Info.plist
```

This PR adjusts all Rogue Amoeba products to use the rogueamoeba.com downloads instead of CloudFront, to ensure that AutoPkg is able to download the latest update as soon as possible. The download speeds will be slower, but speed is not of primary importance here.