### PR TITLE
Fix Vienna Download

### DIFF
--- a/ViennaRSS/Vienna.download.recipe
+++ b/ViennaRSS/Vienna.download.recipe
@@ -20,25 +20,23 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://viennarss.github.io/sparkle-files/changelog.xml</string>
+				<key>asset_regex</key>
+				<string>Vienna\d{1,2}\.\d{1,2}\.\d{1,2}\.tar\.gz</string>
+				<key>github_repo</key>
+				<string>ViennaRSS/vienna-rss</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>find</key>
-				<string>%252F</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
 				<string>/</string>
+				<key>input_string</key>
+				<string>%version%</string>
+				<key>replace</key>
+				<string></string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
@@ -47,9 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.tgz</string>
-				<key>url</key>
-				<string>%output_string%</string>
+				<string>%NAME%-%output_string%.tar.gz</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/ViennaRSS/Vienna.munki.recipe
+++ b/ViennaRSS/Vienna.munki.recipe
@@ -55,7 +55,7 @@
 				<key>additional_pkginfo</key>
 				<dict>
 					<key>version</key>
-					<string>%version%</string>
+					<string>%output_string%</string>
 				</dict>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
Hello, 

The `Vienna.download.recipe` started failing a couple days ago, because the Sparkle feed link for the download info returned an error. 

Because all the releases for Vienna are all available on Github and I could not find the new link for the sparkle feed info and the `GitHubReleasesInfoProvider` seemed like the more consistent solution.

Output for `autopkg run -vv com.github.homebysix.munki.Vienna`: 
```
Processing com.github.homebysix.munki.Vienna...
WARNING: com.github.homebysix.munki.Vienna is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Vienna\\d{1,2}\\.\\d{1,2}\\.\\d{1,2}\\.tar\\.gz',
           'github_repo': 'ViennaRSS/vienna-rss'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Vienna\d{1,2}\.\d{1,2}\.\d{1,2}\.tar\.gz' among asset(s): Vienna3.7.2.b9e97565-dSYM.tar.gz, Vienna3.7.2.tar.gz
GitHubReleasesInfoProvider: Selected asset 'Vienna3.7.2.tar.gz' from release 'Vienna 3.7.2'
{'Output': {'release_notes': '- Speed up database handling (the updated '
                             'database remains fully compatible with all 3.x.x '
                             'versions of Vienna)\r\n'
                             '- Remove preference setting related to '
                             'notifications (already handled by System '
                             'Preferences)\r\n'
                             '- Fix image overflow with certain feeds\r\n'
                             '- Fix download manager and replace NSURLDownload '
                             'with NSURLSessionDownloadTask\r\n'
                             '- Fix scripts handling in menubar\r\n'
                             '- Fix behavior when clicking on Dock icon\r\n'
                             '- Improve handling of URLs containing semicolon '
                             'character in the path component\r\n'
                             '- Update Sparkle to version 1.27 and add an '
                             'EdDSA key\r\n'
                             '- Update procedures for building binaries (use '
                             'Sourceforge for binaries instead of Bintray, fix '
                             'notarization and Github test action)\r\n'
                             '\n'
                             '\n'
                             '[![Download '
                             'Vienna](https://a.fsdn.com/con/app/sf-download-button)](https://sourceforge.net/projects/vienna-rss/files/v_3.7.2/)',
            'url': 'https://github.com/ViennaRSS/vienna-rss/releases/download/v/3.7.2/Vienna3.7.2.tar.gz',
            'version': '/3.7.2'}}
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': '/', 'input_string': '/3.7.2', 'replace': ''}}
FindAndReplace: Replacing "/" with "" in "/3.7.2".
{'Output': {'output_string': '3.7.2'}}
URLDownloader
{'Input': {'filename': 'Vienna-3.7.2.tar.gz',
           'url': 'https://github.com/ViennaRSS/vienna-rss/releases/download/v/3.7.2/Vienna3.7.2.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 17 Oct 2021 13:24:04 GMT
URLDownloader: Storing new ETag header: "f95090091ed4d645eea92bbfbe7319c0"
URLDownloader: Downloaded /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/downloads/Vienna-3.7.2.tar.gz
{'Output': {'download_changed': True,
            'etag': '"f95090091ed4d645eea92bbfbe7319c0"',
            'last_modified': 'Sun, 17 Oct 2021 13:24:04 GMT',
            'pathname': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/downloads/Vienna-3.7.2.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/downloads/Vienna-3.7.2.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/downloads/Vienna-3.7.2.tar.gz',
           'destination_path': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_gzip' from filename Vienna-3.7.2.tar.gz
Unarchiver: Unarchived /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/downloads/Vienna-3.7.2.tar.gz to /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications/Vienna.app',
           'requirement': '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */) and anchor apple generic and '
                          'identifier "uk.co.opencommunity.vienna2"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications/Vienna.app: valid on disk
CodeSignatureVerifier: /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications/Vienna.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications/Vienna.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna.dmg',
           'dmg_root': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications'}}
DmgCreator: Created dmg from /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna/Applications at /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna.dmg
{'Output': {}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '3.7.2'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Vienna is a freeware, open source '
                                      'RSS/Atom newsreader for Mac OS X. ',
                       'developer': 'Barijaona Ramaholimihaso',
                       'display_name': 'Vienna',
                       'name': 'Vienna',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '3.7.2'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'Vienna is a freeware, open source '
                                       'RSS/Atom newsreader for Mac OS X. ',
                        'developer': 'Barijaona Ramaholimihaso',
                        'display_name': 'Vienna',
                        'name': 'Vienna',
                        'unattended_install': True,
                        'version': '3.7.2'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Volumes/munki_repo_test',
           'pkg_path': '/Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/Vienna.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Vienna is a freeware, open source '
                                      'RSS/Atom newsreader for Mac OS X. ',
                       'developer': 'Barijaona Ramaholimihaso',
                       'display_name': 'Vienna',
                       'name': 'Vienna',
                       'unattended_install': True,
                       'version': '3.7.2'},
           'repo_subdirectory': 'apps/Vienna',
           'version_comparison_key': 'CFBundleVersion'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Volumes/munki_repo_test
MunkiImporter: Copied pkginfo to: /Volumes/munki_repo_test/pkgsinfo/apps/Vienna/Vienna-3.7.2.plist
MunkiImporter:            pkg to: /Volumes/munki_repo_test/pkgs/apps/Vienna/Vienna-3.7.2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Vienna',
                                                       'pkg_repo_path': 'apps/Vienna/Vienna-3.7.2.dmg',
                                                       'pkginfo_path': 'apps/Vienna/Vienna-3.7.2.plist',
                                                       'version': '3.7.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'user',
                                         'creation_date': datetime.datetime(2021, 10, 22, 12, 58, 12),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '11.6'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Vienna is a freeware, open source '
                                          'RSS/Atom newsreader for Mac OS X. ',
                           'developer': 'Barijaona Ramaholimihaso',
                           'display_name': 'Vienna',
                           'installer_item_hash': 'dc333db1d293ee376f9498c524aaa3e1dcef224ca171a446bfcdae626ceee3c8',
                           'installer_item_location': 'apps/Vienna/Vienna-3.7.2.dmg',
                           'installer_item_size': 13239,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'uk.co.opencommunity.vienna2',
                                         'CFBundleName': 'Vienna',
                                         'CFBundleShortVersionString': '3.7.2 '
                                                                       ':b9e97565:',
                                         'CFBundleVersion': '7555',
                                         'minosversion': '10.11.0',
                                         'path': '/Applications/Vienna.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleVersion'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Vienna.app'}],
                           'minimum_os_version': '10.11.0',
                           'name': 'Vienna',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.7.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Volumes/munki_repo_test/pkgs/apps/Vienna/Vienna-3.7.2.dmg',
            'pkginfo_repo_path': '/Volumes/munki_repo_test/pkgsinfo/apps/Vienna/Vienna-3.7.2.plist'}}
Receipt written to /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/receipts/com.github.homebysix.munki-receipt-20211022-145813.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/user/Library/AutoPkg/Cache/com.github.homebysix.munki.Vienna/downloads/Vienna-3.7.2.tar.gz  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                    Pkg Repo Path                 Icon Repo Path  
    ----    -------  --------  ------------                    -------------                 --------------  
    Vienna  3.7.2    testing   apps/Vienna/Vienna-3.7.2.plist  apps/Vienna/Vienna-3.7.2.dmg   
```