### PR TITLE
added Apple Silicon packaging support to Docker recipe

### DIFF
--- a/Docker/DockerDesktop.download.recipe
+++ b/Docker/DockerDesktop.download.recipe
@@ -5,13 +5,17 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.2.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Docker Desktop.</string>
+	<string>Downloads the latest version of Docker Desktop.
+
+Change the PLATFORM_ARCH in your override to "arm64" to download Docker for Apple Silicon Macs. Note that the Intel build does not function with Rosetta2, so separate packaging is required to support Apple Silicon Macs.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.DockerDesktop</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>Docker</string>
+		<key>PLATFORM_ARCH</key>
+		<string>amd64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4.1</string>
@@ -21,9 +25,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%PLATFORM_ARCH%.dmg</string>
 				<key>url</key>
-				<string>https://desktop.docker.com/mac/stable/Docker.dmg</string>
+				<string>https://desktop.docker.com/mac/main/%PLATFORM_ARCH%/Docker.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -38,7 +42,7 @@
 				<key>input_path</key>
 				<string>%pathname%/Docker.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.docker.docker" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9BNSXJN65R")</string>
+				<string>identifier "com.docker.docker" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9BNSXJN65R"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
- changed URL to the new format from download page at https://docs.docker.com/desktop/mac/install
- added `%PLATFORM_ARCH%` input variable, set to `amd64` (Intel) by default
- updated description to include info on switching to `arm64` (Apple Silicon) download path
- updated code signature requirement (verified string matches for both Intel and Apple Silicon builds downloaded from above URL)