### PR TITLE
set pkg_path to include PLATFORM_ARCH

### DIFF
--- a/Docker/DockerDesktop.pkg.recipe
+++ b/Docker/DockerDesktop.pkg.recipe
@@ -20,6 +20,11 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%app_name%-%PLATFORM_ARCH%-%version%.pkg</string>
+			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>


### PR DESCRIPTION
- set `pkg_path` to include `PLATFORM_ARCH` (allows unique package creation for Intel and Apple Silicon builds)