### PR TITLE
revise all awscli recipes for v2

### DIFF
--- a/Amazon/AWSCLI.download.recipe
+++ b/Amazon/AWSCLI.download.recipe
@@ -12,36 +12,36 @@
 		<string>AWSCLI</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>awscli-bundle.zip</string>
-				<key>url</key>
-				<string>https://s3.amazonaws.com/aws-cli/awscli-bundle.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://awscli.amazonaws.com/AWSCLIV2.pkg</string>
+			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
+				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/source</string>
-				<key>purge_destination</key>
-				<true/>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: AMZN Mobile LLC (94KV3E626L)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
 		</dict>
 	</array>
 </dict>

--- a/Amazon/AWSCLI.install.recipe
+++ b/Amazon/AWSCLI.install.recipe
@@ -11,12 +11,17 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.homebysix.pkg.AWSCLI</string>
+	<string>com.github.homebysix.download.AWSCLI</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Processor</key>
 			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/Amazon/AWSCLI.munki.recipe
+++ b/Amazon/AWSCLI.munki.recipe
@@ -18,8 +18,12 @@
 			<array>
 				<string>testing</string>
 			</array>
+			<key>category</key>
+			<string>Developer</string>
 			<key>description</key>
-			<string>Amazon CLI Tools, which are symlinked to /usr/local/bin/aws</string>
+			<string>The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services, symlinked into your path at /usr/local/bin/aws</string>
+			<key>developer</key>
+			<string>Amazon Web Services</string>
 			<key>display_name</key>
 			<string>AWS Command Line Interface</string>
 			<key>name</key>
@@ -35,6 +39,8 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
@@ -42,8 +48,6 @@
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
 		</dict>
 	</array>
 </dict>

--- a/Amazon/AWSCLI.munki.recipe
+++ b/Amazon/AWSCLI.munki.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps</string>
+		<string></string>
 		<key>NAME</key>
 		<string>AWSCLI</string>
 		<key>pkginfo</key>
@@ -19,9 +19,9 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>Downloads the latest version of Amazon EC2 Tools and creates a package for deployment.</string>
+			<string>Amazon CLI Tools, which are symlinked to /usr/local/bin/aws</string>
 			<key>display_name</key>
-			<string>AWSCLI</string>
+			<string>AWS Command Line Interface</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -31,14 +31,14 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.homebysix.pkg.AWSCLI</string>
+	<string>com.github.homebysix.download.AWSCLI</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Amazon/AWSCLI.munki.recipe
+++ b/Amazon/AWSCLI.munki.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string></string>
+		<string>apps</string>
 		<key>NAME</key>
 		<string>AWSCLI</string>
 		<key>pkginfo</key>

--- a/Amazon/AWSCLI.pkg.recipe
+++ b/Amazon/AWSCLI.pkg.recipe
@@ -37,12 +37,12 @@ Tags are used since contents of pkg don't have easily parse-able version, probab
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>Copier</string>
+			<string>PkgCopier</string>
 			<key>Arguments</key>
 			<dict>
-				<key>source_path</key>
+				<key>source_pkg</key>
 				<string>%pathname%</string>
-				<key>destination_path</key>
+				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>
 		</dict>

--- a/Amazon/AWSCLI.pkg.recipe
+++ b/Amazon/AWSCLI.pkg.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Creates a pkg to deploy http://aws.amazon.com/cli/</string>
+	<string>Creates a pkg to deploy http://aws.amazon.com/cli/
+
+Tags are used since contents of pkg don't have easily parse-able version, probably brittle.
+</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.AWSCLI</string>
 	<key>Input</key>
@@ -18,120 +21,30 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>tmp</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
+				<key>Comment</key>
+				<string>Regex allows for double-digits in any position but assumes 1.2.3 format</string>
+				<key>re_pattern</key>
+				<string>\d*\.\d*\.\d*</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+				<key>url</key>
+				<string>https://api.github.com/repos/aws/aws-cli/tags</string>
+			 </dict>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/tmp/awscli-bundle</string>
-				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/source/awscli-bundle</string>
-			</dict>
-			<key>Comment</key>
-			<string>Copy resources.</string>
 			<key>Processor</key>
 			<string>Copier</string>
-		</dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/source/awscli-bundle/packages/awscli-*.tar.gz</string>
+				<key>source_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>find</key>
-				<string>%RECIPE_CACHE_DIR%/source/awscli-bundle/packages/awscli-</string>
-				<key>input_string</key>
-				<string>%found_filename%</string>
-				<key>replace</key>
-				<string></string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>find</key>
-				<string>.tar.gz</string>
-				<key>input_string</key>
-				<string>%output_string%</string>
-				<key>replace</key>
-				<string></string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>infofile</key>
-				<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-				<key>pkgroot</key>
-				<string>%pkgroot%</string>
-				<key>pkgtype</key>
-				<string>flat</string>
-				<key>template_path</key>
-				<string>%RECIPE_DIR%/PackageInfoTemplate</string>
-				<key>version</key>
-				<string>%output_string%</string>
-			</dict>
-			<key>Comment</key>
-			<string>Create a PackageInfo file using the template.</string>
-			<key>Processor</key>
-			<string>PkgInfoCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>wheel</string>
-							<key>path</key>
-							<string>tmp</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>com.github.homebysix.%NAME%</string>
-					<key>infofile</key>
-					<string>%RECIPE_CACHE_DIR%/PackageInfo</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>resources</key>
-					<string>%RECIPE_DIR%/Resources</string>
-					<key>scripts</key>
-					<string>%RECIPE_DIR%/Scripts</string>
-				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
-			</dict>
-			<key>Comment</key>
-			<string>Build the package.</string>
-			<key>Processor</key>
-			<string>PkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/Amazon/PackageInfoTemplate
+++ b/Amazon/PackageInfoTemplate
@@ -1,2 +1,0 @@
-<pkg-info format-version="2" identifier="com.github.homebysix.AWSCLI" install-location="/" auth="root">
-</pkg-info>


### PR DESCRIPTION
pkg recipe version handling is brittle, but commented.  Couldn't get version by unpacking and plist reading since it's not an app bundle, moving on since optimal for munki and doesn't (at this moment) break anyone expecting a pkg named with a version in e.g. jamf recipes elsewhere.
@macmule feel free to yell at me about this since y'all inherit from it for https://github.com/autopkg/dataJAR-recipes/blob/master/AWSCLI/AWSCLI.jss.recipe, although it seems you haven't touched it since 2017 and the Jamf world has moved away from these types of recipes anyway AFAICT (there's no other .jss recipes I'm aware of)