### PR TITLE
added `%BUILD%` string to GitHub Desktop `pkgname`

### DIFF
--- a/GitHub/GitHubDesktop.download.recipe
+++ b/GitHub/GitHubDesktop.download.recipe
@@ -7,7 +7,7 @@
 
 Valid BUILD arguments are:
 - "darwin": Downloads GitHub Desktop for Intel Macs
-- "arm64": Downloads GitHub Desktop for Apple Silicon Macs
+- "darwin-arm64": Downloads GitHub Desktop for Apple Silicon Macs
 	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.GitHubDesktop</string>

--- a/GitHub/GitHubDesktop.download.recipe
+++ b/GitHub/GitHubDesktop.download.recipe
@@ -4,9 +4,10 @@
 <dict>
 	<key>Description</key>
 	<string>Downloads the latest version of GitHub Desktop.
+
 Valid BUILD arguments are:
-		x64: darwin
-		arm64: darwin-arm64
+- "darwin": Downloads GitHub Desktop for Intel Macs
+- "arm64": Downloads GitHub Desktop for Apple Silicon Macs
 	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.GitHubDesktop</string>

--- a/GitHub/GitHubDesktop.pkg.recipe
+++ b/GitHub/GitHubDesktop.pkg.recipe
@@ -40,7 +40,7 @@
 					<key>options</key>
 					<string>purge_ds_store</string>
 					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
+					<string>%NAME%-%BUILD%-%version%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 					<key>scripts</key>


### PR DESCRIPTION
- added `%BUILD%` string to GitHub Desktop `pkgname` to differentiate between Apple Silicon and Intel packages