### PR TITLE
Create URLProvider for the R Project for multi-arch support

### DIFF
--- a/R/R.download.recipe
+++ b/R/R.download.recipe
@@ -3,11 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of R for Mac OS X. (Also known as "The R Project for Statistical Computing.")</string>
+	<string>Downloads the latest version of R for macOS. (Also known as "The R Project for Statistical Computing.")
+
+Possible values for the ARCH input variable include:
+- 'x86_64' (Intel, default)
+- 'arm64' (Apple Silicon)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.R</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>NAME</key>
 		<string>R</string>
 	</dict>
@@ -18,19 +25,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>&lt;a href="base\/(?P&lt;filename&gt;R-(?P&lt;version&gt;[\d.]+)\.pkg)"&gt;R-[\d.]+\.pkg&lt;/a&gt;</string>
-				<key>url</key>
-				<string>https://cran.r-project.org/bin/macosx/</string>
+				<key>architecture</key>
+				<string>%ARCH%</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>RProjectURLProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://cran.r-project.org/bin/macosx/base/%filename%</string>
+				<key>filename</key>
+				<string>%NAME%_%ARCH%-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/R/R.install.recipe
+++ b/R/R.install.recipe
@@ -3,11 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Installs the latest version of R for Mac OS X. (Also known as "The R Project for Statistical Computing.")</string>
+	<string>Installs the latest version of R for macOS. (Also known as "The R Project for Statistical Computing.")
+
+Possible values for the ARCH input variable include:
+- 'x86_64' (Intel, default)
+- 'arm64' (Apple Silicon)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.R</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>NAME</key>
 		<string>R</string>
 	</dict>

--- a/R/R.munki.recipe
+++ b/R/R.munki.recipe
@@ -3,11 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of R for Mac OS X and imports it into Munki. (Also known as "The R Project for Statistical Computing.")</string>
+	<string>Downloads the latest version of R for macOS and imports it into Munki. (Also known as "The R Project for Statistical Computing.")
+
+Possible values for the ARCH input variable include:
+- 'x86_64' (Intel, default)
+- 'arm64' (Apple Silicon)
+
+NOTE: If you change the ARCH variable, be sure to also include a corresponding 'supported_architectures' array in the Munki pkginfo.
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.R</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/R</string>
 		<key>NAME</key>

--- a/R/R.pkg.recipe
+++ b/R/R.pkg.recipe
@@ -3,11 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of R for Mac OS X. (Also known as "The R Project for Statistical Computing.") This recipe does not perform any processing, because the R download is already in pkg format.</string>
+	<string>Downloads the latest version of R for macOS. (Also known as "The R Project for Statistical Computing.") This recipe does not perform any processing, because the R download is already in pkg format.
+
+Possible values for the ARCH input variable include:
+- 'x86_64' (Intel, default)
+- 'arm64' (Apple Silicon)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.R</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>NAME</key>
 		<string>R</string>
 	</dict>

--- a/R/RProjectURLProvider.py
+++ b/R/RProjectURLProvider.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Elliot Jordan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+# pylint: disable=unused-import
+from autopkglib import ProcessorError, URLGetter
+
+__all__ = ["RProjectURLProvider"]
+
+# R project Mac downloads page
+DL_PAGE = "https://cran.r-project.org/bin/macosx/"
+
+
+class RProjectURLProvider(URLGetter):
+    """Provides a download URL for the latest R Project
+    (https://cran.r-project.org/) product release."""
+
+    input_variables = {
+        "architecture": {
+            "required": False,
+            "description": "Architecture of the R package to download. "
+            "Possible values are 'x86_64' (Intel) or 'arm64' (Apple Silicon). "
+            "Defaults to 'x86_64' (Intel).",
+        },
+    }
+    output_variables = {
+        "url": {"description": "URL to the latest R release."},
+        "version": {"description": "Version of the latest R release."},
+    }
+    description = __doc__
+
+    def main(self):
+        """Main process."""
+
+        # Read and validate input variables
+        arch = self.env.get("architecture", "x86_64")
+        if arch not in ("x86_64", "arm64"):
+            raise ProcessorError("Architecture must be one of: x86_64, arm64")
+
+        # Prepare regular expression
+        if arch == "x86_64":
+            pattern = r'base\/(?P<file>R-(?P<vers>[\d.]+)\.pkg)">R-[\d.]+\.pkg</a>'
+            url_base = "https://cran.r-project.org/bin/macosx/base/"
+        elif arch == "arm64":
+            pattern = r'base\/(?P<file>R-(?P<vers>[\d.]+)-arm64\.pkg)">R-[\d.]+-arm64\.pkg</a>'
+            url_base = "https://cran.r-project.org/bin/macosx/big-sur-arm64/base/"
+
+        # Get and parse download page contents
+        download_page_html = self.download(DL_PAGE, text=True)
+        m = re.search(pattern, download_page_html)
+        if not m:
+            raise ProcessorError(f"No match found on {DL_PAGE}")
+
+        # Set URL and version in environment
+        self.env["url"] = url_base + m.groupdict()["file"]
+        self.output("Found url: %s" % self.env["url"])
+        self.env["version"] = m.groupdict()["vers"]
+        self.output("Found version: %s" % self.env["version"])
+
+
+if __name__ == "__main__":
+    PROCESSOR = RProjectURLProvider()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
The R project now offers both Intel and Apple Silicon installers, and their URL schemes are such that providing both with a single recipe using `URLTextSearcher` is impossible.

Therefore, I've added a URLProvider that produces the correct URL and version given a desired architecture: `arm64` or `x86_64`.

Those who override the Munki recipe may wish to also supply a `supported_architectures` key/value that matches their `ARCH` choice. I've noted that in the description.

Resolves #510.