### PR TITLE
Cocktail recipe revisions, including addition of CocktailReleasesInfoProvider processor

### DIFF
--- a/Cocktail/Cocktail-10.10.download.recipe
+++ b/Cocktail/Cocktail-10.10.download.recipe
@@ -8,28 +8,25 @@
 	<string>com.github.homebysix.download.Cocktail-10.10</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>10.10</string>
 		<key>NAME</key>
-		<string>Cocktail-10.10</string>
+		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>CocktailReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -40,23 +37,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.yosemite" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "49Q84U5WS2"</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/Cocktail-10.10.install.recipe
+++ b/Cocktail/Cocktail-10.10.install.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.10</string>
 	<key>Process</key>
@@ -20,32 +20,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
+				<key>dmg_path</key>
 				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Cocktail/Cocktail-10.10.munki.recipe
+++ b/Cocktail/Cocktail-10.10.munki.recipe
@@ -11,7 +11,7 @@
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/Cocktail</string>
 		<key>NAME</key>
-		<string>Cocktail-10.10</string>
+		<string>Cocktail</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -19,11 +19,11 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>General maintenance and optimization utility.</string>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
 			<key>developer</key>
 			<string>Maintain</string>
 			<key>display_name</key>
-			<string>Cocktail for Yosemite</string>
+			<string>Cocktail</string>
 			<key>maximum_os_version</key>
 			<string>10.10.99</string>
 			<key>minimum_os_version</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.10</string>
 	<key>Process</key>
@@ -43,19 +43,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Cocktail/Cocktail-10.10.pkg.recipe
+++ b/Cocktail/Cocktail-10.10.pkg.recipe
@@ -8,13 +8,11 @@
 	<string>com.github.homebysix.pkg.Cocktail-10.10</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.yosemite</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.10</string>
 	<key>Process</key>
@@ -22,35 +20,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>mode</key>
-							<string>0775</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
+				<key>app_path</key>
+				<string>%pathname%/Cocktail.app</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/Cocktail/Cocktail-10.11.download.recipe
+++ b/Cocktail/Cocktail-10.11.download.recipe
@@ -10,28 +10,25 @@
 	<string>com.github.homebysix.download.Cocktail-10.11</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>10.11</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>CocktailReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -42,23 +39,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.elcapitan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "49Q84U5WS2"</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/Cocktail-10.11.install.recipe
+++ b/Cocktail/Cocktail-10.11.install.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.11</string>
 	<key>Process</key>
@@ -23,18 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Cocktail/Cocktail-10.11.munki.recipe
+++ b/Cocktail/Cocktail-10.11.munki.recipe
@@ -21,9 +21,13 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>General maintenance and optimization utility.</string>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
 			<key>developer</key>
-			<string>Kristofer Szymanski</string>
+			<string>Maintain</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
 			<key>display_name</key>
 			<string>Cocktail</string>
 			<key>name</key>
@@ -33,7 +37,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.11</string>
 	<key>Process</key>
@@ -41,19 +45,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Cocktail/Cocktail-10.11.pkg.recipe
+++ b/Cocktail/Cocktail-10.11.pkg.recipe
@@ -10,13 +10,11 @@
 	<string>com.github.homebysix.pkg.Cocktail-10.11</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.elcapitan</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.11</string>
 	<key>Process</key>
@@ -24,33 +22,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
+				<key>app_path</key>
+				<string>%pathname%/Cocktail.app</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/Cocktail/Cocktail-10.12.download.recipe
+++ b/Cocktail/Cocktail-10.12.download.recipe
@@ -10,28 +10,25 @@
 	<string>com.github.homebysix.download.Cocktail-10.12</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>10.12</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://www.maintain.se/downloads/sparkle/sierra/sierra.xml</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>CocktailReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -42,23 +39,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.sierra" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "49Q84U5WS2"</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/Cocktail-10.12.install.recipe
+++ b/Cocktail/Cocktail-10.12.install.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.12</string>
 	<key>Process</key>
@@ -23,18 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Cocktail/Cocktail-10.12.munki.recipe
+++ b/Cocktail/Cocktail-10.12.munki.recipe
@@ -21,9 +21,13 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>General maintenance and optimization utility.</string>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
 			<key>developer</key>
-			<string>Kristofer Szymanski</string>
+			<string>Maintain</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
 			<key>display_name</key>
 			<string>Cocktail</string>
 			<key>name</key>
@@ -33,7 +37,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.12</string>
 	<key>Process</key>
@@ -41,19 +45,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Cocktail/Cocktail-10.12.pkg.recipe
+++ b/Cocktail/Cocktail-10.12.pkg.recipe
@@ -10,13 +10,11 @@
 	<string>com.github.homebysix.pkg.Cocktail-10.12</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.sierra</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.12</string>
 	<key>Process</key>
@@ -24,33 +22,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
+				<key>app_path</key>
+				<string>%pathname%/Cocktail.app</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/Cocktail/Cocktail-10.13.download.recipe
+++ b/Cocktail/Cocktail-10.13.download.recipe
@@ -10,28 +10,25 @@
 	<string>com.github.homebysix.download.Cocktail-10.13</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>10.13</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://www.maintain.se/downloads/sparkle/highsierra/highsierra.xml</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>CocktailReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -42,23 +39,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.highsierra" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "49Q84U5WS2"</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/Cocktail-10.13.install.recipe
+++ b/Cocktail/Cocktail-10.13.install.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.13</string>
 	<key>Process</key>
@@ -23,18 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Cocktail/Cocktail-10.13.munki.recipe
+++ b/Cocktail/Cocktail-10.13.munki.recipe
@@ -21,9 +21,13 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>General maintenance and optimization utility.</string>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
 			<key>developer</key>
-			<string>Kristofer Szymanski</string>
+			<string>Maintain</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
 			<key>display_name</key>
 			<string>Cocktail</string>
 			<key>name</key>
@@ -33,7 +37,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.13</string>
 	<key>Process</key>
@@ -41,19 +45,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Cocktail/Cocktail-10.13.pkg.recipe
+++ b/Cocktail/Cocktail-10.13.pkg.recipe
@@ -10,13 +10,11 @@
 	<string>com.github.homebysix.pkg.Cocktail-10.13</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.maintain.cocktail.highsierra</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.13</string>
 	<key>Process</key>
@@ -24,33 +22,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
+				<key>app_path</key>
+				<string>%pathname%/Cocktail.app</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/Cocktail/Cocktail-10.14.download.recipe
+++ b/Cocktail/Cocktail-10.14.download.recipe
@@ -10,28 +10,25 @@
 	<string>com.github.homebysix.download.Cocktail-10.14</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>10.14</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://www.maintain.se/downloads/sparkle/mojave/mojave.xml</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>CocktailReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -42,23 +39,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.mojave12" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HC63V5YZGB</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/Cocktail-10.14.munki.recipe
+++ b/Cocktail/Cocktail-10.14.munki.recipe
@@ -21,9 +21,13 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>General maintenance and optimization utility.</string>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
 			<key>developer</key>
-			<string>Kristofer Szymanski</string>
+			<string>Maintain</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
 			<key>display_name</key>
 			<string>Cocktail</string>
 			<key>name</key>
@@ -33,7 +37,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.14</string>
 	<key>Process</key>
@@ -41,19 +45,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Cocktail/Cocktail-10.14.pkg.recipe
+++ b/Cocktail/Cocktail-10.14.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.14</string>
 	<key>Process</key>
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>

--- a/Cocktail/Cocktail-10.15.download.recipe
+++ b/Cocktail/Cocktail-10.15.download.recipe
@@ -8,28 +8,25 @@
 	<string>com.github.homebysix.download.Cocktail-10.15</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>10.15</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://www.maintain.se/downloads/sparkle/catalina/catalina.xml</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>CocktailReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -40,23 +37,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.catalina13" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HC63V5YZGB</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/Cocktail-10.15.munki.recipe
+++ b/Cocktail/Cocktail-10.15.munki.recipe
@@ -19,11 +19,15 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>General maintenance and optimization utility.</string>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
 			<key>developer</key>
-			<string>Kristofer Szymanski</string>
+			<string>Maintain</string>
 			<key>display_name</key>
 			<string>Cocktail</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -31,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.15</string>
 	<key>Process</key>
@@ -39,19 +43,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Cocktail/Cocktail-10.15.pkg.recipe
+++ b/Cocktail/Cocktail-10.15.pkg.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.15</string>
 	<key>Process</key>
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Cocktail.app</string>
+				<string>%pathname%/Cocktail.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>

--- a/Cocktail/Cocktail-10.6.download.recipe
+++ b/Cocktail/Cocktail-10.6.download.recipe
@@ -12,9 +12,18 @@
 		<string>Cocktail-10.6</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated. Please use the new Cocktail.download, Cocktail.pkg, or Cocktail.munki recipes for versions of Cocktail that support macOS Yosemite and above.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Cocktail/Cocktail-10.6.install.recipe
+++ b/Cocktail/Cocktail-10.6.install.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.6</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.6.munki.recipe
+++ b/Cocktail/Cocktail-10.6.munki.recipe
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.6</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.6.pkg.recipe
+++ b/Cocktail/Cocktail-10.6.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.6</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.7.download.recipe
+++ b/Cocktail/Cocktail-10.7.download.recipe
@@ -12,9 +12,18 @@
 		<string>Cocktail-10.7</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated. Please use the new Cocktail.download, Cocktail.pkg, or Cocktail.munki recipes for versions of Cocktail that support macOS Yosemite and above.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Cocktail/Cocktail-10.7.install.recipe
+++ b/Cocktail/Cocktail-10.7.install.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.7</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.7.munki.recipe
+++ b/Cocktail/Cocktail-10.7.munki.recipe
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.7</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.7.pkg.recipe
+++ b/Cocktail/Cocktail-10.7.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.7</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.8.download.recipe
+++ b/Cocktail/Cocktail-10.8.download.recipe
@@ -12,9 +12,18 @@
 		<string>Cocktail-10.8</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated. Please use the new Cocktail.download, Cocktail.pkg, or Cocktail.munki recipes for versions of Cocktail that support macOS Yosemite and above.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Cocktail/Cocktail-10.8.install.recipe
+++ b/Cocktail/Cocktail-10.8.install.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.8</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.8.munki.recipe
+++ b/Cocktail/Cocktail-10.8.munki.recipe
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.8</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.8.pkg.recipe
+++ b/Cocktail/Cocktail-10.8.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.8</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.9.download.recipe
+++ b/Cocktail/Cocktail-10.9.download.recipe
@@ -12,9 +12,18 @@
 		<string>Cocktail-10.9</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated. Please use the new Cocktail.download, Cocktail.pkg, or Cocktail.munki recipes for versions of Cocktail that support macOS Yosemite and above.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Cocktail/Cocktail-10.9.install.recipe
+++ b/Cocktail/Cocktail-10.9.install.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.9</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.9.munki.recipe
+++ b/Cocktail/Cocktail-10.9.munki.recipe
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.9</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail-10.9.pkg.recipe
+++ b/Cocktail/Cocktail-10.9.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Cocktail-10.9</string>
 	<key>Process</key>

--- a/Cocktail/Cocktail.download.recipe
+++ b/Cocktail/Cocktail.download.recipe
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of a particular MAJOR_VERSION of Cocktail.
+
+MAJOR_VERSION should correspond to a macOS release version. Supported values include:
+- 12 for Monterey (default)
+- 11 for Big Sur
+- 10.15 for Catalina
+- 10.14 for Mojave
+- 10.13 for High Sierra
+- 10.12 for Sierra
+- 10.11 for El Capitan
+- 10.10 for Yosemite
+
+This recipe does not support older major versions than Yosemite.
+	</string>
+	<key>Identifier</key>
+	<string>com.github.homebysix.download.Cocktail</string>
+	<key>Input</key>
+	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>12</string>
+		<key>NAME</key>
+		<string>Cocktail</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CocktailReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Cocktail.app</string>
+				<key>requirement</key>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Cocktail.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Cocktail/Cocktail.munki.recipe
+++ b/Cocktail/Cocktail.munki.recipe
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Cocktail and imports it into Munki.
+
+See the Cocktail.download.recipe for information about selecting a MAJOR_VERSION.
+	</string>
+	<key>Identifier</key>
+	<string>com.github.homebysix.munki.Cocktail</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Cocktail</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Cocktail is a general purpose utility for macOS that lets you clean, repair and optimize your Mac.</string>
+			<key>developer</key>
+			<string>Maintain</string>
+			<key>display_name</key>
+			<string>Cocktail</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.homebysix.download.Cocktail</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Cocktail/Cocktail.pkg.recipe
+++ b/Cocktail/Cocktail.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Cocktail and creates a package.
+
+		See the Cocktail.download.recipe for information about selecting a MAJOR_VERSION.</string>
+	<key>Identifier</key>
+	<string>com.github.homebysix.pkg.Cocktail</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Cocktail</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.homebysix.download.Cocktail</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>app_path</key>
+				<string>%pathname%/Cocktail.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Cocktail/CocktailBigSur.download.recipe
+++ b/Cocktail/CocktailBigSur.download.recipe
@@ -8,19 +8,25 @@
 	<string>com.github.homebysix.download.CocktailBigSur</string>
 	<key>Input</key>
 	<dict>
+		<key>MAJOR_VERSION</key>
+		<string>11</string>
 		<key>NAME</key>
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>http://usa.maintain.se/Cocktail14BSE.dmg</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
+			<key>Processor</key>
+			<string>CocktailReleasesInfoProvider</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -34,7 +40,7 @@
 				<key>input_path</key>
 				<string>%pathname%/Cocktail.app</string>
 				<key>requirement</key>
-				<string>identifier "com.maintain.cocktail.bigsur14" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HC63V5YZGB</string>
+				<string>identifier "%bundle_id%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "%cert_leaf_ou%"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Cocktail/CocktailBigSur.munki.recipe
+++ b/Cocktail/CocktailBigSur.munki.recipe
@@ -24,6 +24,10 @@
 			<string>Kristofer Szymanski</string>
 			<key>display_name</key>
 			<string>Cocktail</string>
+			<key>maximum_os_version</key>
+			<string>%MAJOR_VERSION%.99</string>
+			<key>minimum_os_version</key>
+			<string>%MAJOR_VERSION%</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -31,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.CocktailBigSur</string>
 	<key>Process</key>

--- a/Cocktail/CocktailBigSur.pkg.recipe
+++ b/Cocktail/CocktailBigSur.pkg.recipe
@@ -12,7 +12,7 @@
 		<string>Cocktail</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.CocktailBigSur</string>
 	<key>Process</key>

--- a/Cocktail/CocktailReleasesInfoProvider.py
+++ b/Cocktail/CocktailReleasesInfoProvider.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Elliot Jordan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from autopkglib import URLGetter, APLooseVersion  # noqa: F401
+
+__all__ = ["CocktailReleasesInfoProvider"]
+
+# Information about available Cocktail releases
+RELEASES = {
+    "10.10": {
+        "filename": "Cocktail8YE.dmg",
+        "bundle_id": "com.maintain.cocktail.yosemite",
+    },
+    "10.11": {
+        "filename": "Cocktail9ECE.dmg",
+        "bundle_id": "com.maintain.cocktail.elcapitan",
+    },
+    "10.12": {
+        "filename": "Cocktail10SE.dmg",
+        "bundle_id": "com.maintain.cocktail.sierra",
+    },
+    "10.13": {
+        "filename": "Cocktail11HSE.dmg",
+        "bundle_id": "com.maintain.cocktail.highsierra",
+    },
+    "10.14": {
+        "filename": "Cocktail12ME.dmg",
+        "bundle_id": "com.maintain.cocktail.mojave12",
+    },
+    "10.15": {
+        "filename": "Cocktail13CE.dmg",
+        "bundle_id": "com.maintain.cocktail.catalina13",
+    },
+    "11": {
+        "filename": "Cocktail14BSE.dmg",
+        "bundle_id": "com.maintain.cocktail.bigsur14",
+    },
+    "12": {
+        "filename": "Cocktail15ME.dmg",
+        "bundle_id": "com.maintain.cocktail.monterey15",
+    },
+}
+
+# Base URL for downloading releases
+BASE_URL = "https://www.maintain.se/downloads/"
+
+# Default major version if none is provided
+DEFAULT_MAJOR_VERSION = "12"
+
+
+class CocktailReleasesInfoProvider(URLGetter):
+    """Provides a download URL and build number for the latest Cocktail
+    release."""
+
+    input_variables = {
+        "major_version": {
+            "required": False,
+            "description": "Major version of macOS for which to download a "
+            "compatible Cocktail release. Default is %s" % DEFAULT_MAJOR_VERSION,
+        }
+    }
+    output_variables = {
+        "url": {
+            "description": "URL to the download the latest specified Cocktail release."
+        },
+        "bundle_id": {
+            "description": "Bundle identifier of the specified Cocktail release."
+        },
+        "cert_leaf_ou": {
+            "description": "Certificate leaf identifier used for code signature verification."
+        },
+    }
+    description = __doc__
+
+    def main(self):
+        """Main process."""
+
+        # Set input variable
+        major_version = self.env.get("major_version", DEFAULT_MAJOR_VERSION)
+
+        # Determine and set output variables
+        self.env["url"] = BASE_URL + RELEASES[major_version]["filename"]
+        self.output("Found URL: %s" % self.env["url"])
+        self.env["bundle_id"] = RELEASES[major_version]["bundle_id"]
+
+        # Determine and set code signature verification cert leaf
+        if APLooseVersion(major_version) < APLooseVersion("10.14"):
+            self.env["cert_leaf_ou"] = "49Q84U5WS2"
+        else:
+            self.env["cert_leaf_ou"] = "HC63V5YZGB"
+
+
+if __name__ == "__main__":
+    PROCESSOR = CocktailReleasesInfoProvider()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
This pull request adds a `MAJOR_VERSION` input variable that can be used to easily determine which version of macOS you  want a Cocktail release for. The new generic Cocktail.download, Cocktail.munki, and Cocktail.pkg recipes support Monterey by default, but can be used for older releases as well.

Closes #513.