### PR TITLE
Update Grammarly.download.recipe

### DIFF
--- a/Grammarly/Grammarly.download.recipe
+++ b/Grammarly/Grammarly.download.recipe
@@ -2,65 +2,65 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of Grammarly.</string>
-	<key>Identifier</key>
-	<string>com.github.homebysix.download.Grammarly</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Grammarly</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.6.1</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>appcast_url</key>
-				<string>https://download-mac.grammarly.com/appcast.xml</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/Grammarly Installer.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.grammarly.ProjectLlama" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W8F64X92K3)</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Grammarly Installer.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict>
-	</array>
+    <key>Comment</key>
+    <string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
+    <key>Description</key>
+    <string>Downloads the latest version of Grammarly.</string>
+    <key>Identifier</key>
+    <string>com.github.homebysix.download.Grammarly</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Grammarly</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.6.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>https://download-mac.ppgr.io/appcast.xml</string>
+            </dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Grammarly Installer.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.grammarly.ProjectLlama" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W8F64X92K3)</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%pathname%/Grammarly Installer.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi, @homebysix 

Grammerly is currently failing with `Processor: SparkleUpdateInfoProvider: Error: Error parsing XML from appcast feed.` 

Looks like the feed is no longer valid or it's offline

I've found an alternate Sparkle Feed URL https://download-mac.ppgr.io/appcast.xml
 
This PR updates Sparkle Feed URL to the working one. 

```
autopkg run -vvv /Users/paul/Documents/GitHub/homebysix-recipes/Grammarly/Grammarly.download.recipe
Processing /Users/paul/Documents/GitHub/homebysix-recipes/Grammarly/Grammarly.download.recipe...
WARNING: /Users/paul/Documents/GitHub/homebysix-recipes/Grammarly/Grammarly.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.4.1',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'Grammarly',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly',
 'RECIPE_DIR': '/Users/paul/Documents/GitHub/homebysix-recipes/Grammarly',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/paul/Documents/GitHub/homebysix-recipes/Grammarly/Grammarly.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer': {'URL': 'https://github.com/hjuutilainen/autopkg-virustotalanalyzer.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/munki_repo',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer'],
 'VIRUSTOTAL_API_KEY': '***************************************',
 'VIRUSTOTAL_AUTO_SUBMIT': True,
 'VIRUSTOTAL_AUTO_SUBMIT_MAX_SIZE': 1073741824,
 'VIRUSTOTAL_SLEEP_SECONDS': 30,
 'verbose': 3}
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://download-mac.ppgr.io/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.6.0.2
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.6.0
SparkleUpdateInfoProvider: Found URL https://download-mac.ppgr.io/versions/1.6.0.2/Grammarly.dmg
{'Output': {'url': 'https://download-mac.ppgr.io/versions/1.6.0.2/Grammarly.dmg',
            'version': '1.6.0'}}
URLDownloader
{'Input': {'filename': 'Grammarly-1.6.0.dmg',
           'url': 'https://download-mac.ppgr.io/versions/1.6.0.2/Grammarly.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 09 Jun 2022 18:44:24 GMT
URLDownloader: Storing new ETag header: "b0a6d0b50ce25d69964b52354fa91a2e-3"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg
{'Output': {'download_changed': True,
            'etag': '"b0a6d0b50ce25d69964b52354fa91a2e-3"',
            'last_modified': 'Thu, 09 Jun 2022 18:44:24 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg/Grammarly '
                         'Installer.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.grammarly.ProjectLlama" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = W8F64X92K3)'}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.w2ZQxD/Grammarly Installer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.w2ZQxD/Grammarly Installer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.w2ZQxD/Grammarly Installer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg/Grammarly '
                               'Installer.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg
Versioner: Found version 1.6.0.2 in file /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg/Grammarly Installer.app/Contents/Info.plist
{'Output': {'version': '1.6.0.2'}}
{'AUTOPKG_VERSION': '2.4.1',
 'CHECK_FILESIZE_ONLY': False,
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'Grammarly',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly',
 'RECIPE_DIR': '/Users/paul/Documents/GitHub/homebysix-recipes/Grammarly',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/paul/Documents/GitHub/homebysix-recipes/Grammarly/Grammarly.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer': {'URL': 'https://github.com/hjuutilainen/autopkg-virustotalanalyzer.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/munki_repo',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/Shared/munki_repo/com.github.hjuutilainen.autopkg-virustotalanalyzer'],
 'VIRUSTOTAL_API_KEY': '****************************',
 'VIRUSTOTAL_AUTO_SUBMIT': True,
 'VIRUSTOTAL_AUTO_SUBMIT_MAX_SIZE': 1073741824,
 'VIRUSTOTAL_SLEEP_SECONDS': 30,
 'additional_pkginfo': {},
 'appcast_url': 'https://download-mac.ppgr.io/appcast.xml',
 'download_changed': True,
 'etag': '"b0a6d0b50ce25d69964b52354fa91a2e-3"',
 'filename': 'Grammarly-1.6.0.dmg',
 'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg/Grammarly '
               'Installer.app',
 'input_plist_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg/Grammarly '
                     'Installer.app/Contents/Info.plist',
 'last_modified': 'Thu, 09 Jun 2022 18:44:24 GMT',
 'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg',
 'plist_version_key': 'CFBundleVersion',
 'prefetch_filename': False,
 'requirement': 'anchor apple generic and identifier '
                '"com.grammarly.ProjectLlama" and (certificate '
                'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or '
                'certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ '
                'and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = W8F64X92K3)',
 'skip_single_root_dir': False,
 'url': 'https://download-mac.ppgr.io/versions/1.6.0.2/Grammarly.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': '1.6.0.2'}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/receipts/Grammarly.download-receipt-20220616-141227.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Grammarly/downloads/Grammarly-1.6.0.dmg  
```

Thanks
Paul