### PR TITLE
Add VERSIONTYPE Input to allow overriding version source

### DIFF
--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -12,6 +12,8 @@
 		<string>us.zoom.xos</string>
 		<key>NAME</key>
 		<string>Zoom</string>
+		<key>VERSIONTYPE</key>
+		<string>CFBundleVersion</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.1</string>
@@ -62,7 +64,7 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/zoom.us.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
-					<key>CFBundleVersion</key>
+					<key>%VERSIONTYPE%</key>
 					<string>version</string>
 					<key>LSMinimumSystemVersion</key>
 					<string>min_os_version</string>


### PR DESCRIPTION
Moves key used for sourcing the version from Info.plist (ie CFBundleVersion) into an Input so it can be overridden if required.
This should provide a solution for #526 - VERSIONTYPE can be set to CFBundleShortVersionString to provide the version in the format required by Jamf Pro Patch Management.