### PR TITLE
Update Python path in processors to reflect changes in macOS 12.3+

### DIFF
--- a/Quicksilver/FoundationDmgVersioner.py
+++ b/Quicksilver/FoundationDmgVersioner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=no-self-use, no-else-raise, invalid-name
+# pylint: disable=no-else-raise, invalid-name
 #
 # Based on AppDmgVersioner, Copyright 2010 Per Olofsson
 # Adapted to use Foundation, 2020 Graham Pugh

--- a/Quicksilver/FoundationPkgCreator.py
+++ b/Quicksilver/FoundationPkgCreator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=no-self-use, no-else-raise, invalid-name
+# pylint: disable=no-else-raise, invalid-name
 #
 # Based on AppPkgCreator, Copyright 2016 Greg Neagle
 # Adapted to use Foundation, 2020 Graham Pugh

--- a/Zoom/Zoom7zUnarchiver.py
+++ b/Zoom/Zoom7zUnarchiver.py
@@ -75,7 +75,6 @@ class Zoom7zUnarchiver(Processor):  # pylint: disable=invalid-name
 
     def get_archive_format(self, archive_path):
         """Guess archive format based on filename extension."""
-        # pylint: disable=no-self-use
         for format_str, extns in EXTNS.items():
             for extn in extns:
                 if archive_path.endswith(extn):

--- a/soma-zone/XZUnarchiver.py
+++ b/soma-zone/XZUnarchiver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 
 # Copyright 2019 Armin Briegel and 2022 Elliot Jordan


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. This pull request adjusts the "shebang" interpreter paths of processors to replace `/usr/bin/env python` with the AutoPkg Python 3 path.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/env python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.

Thank you for your consideration!