### PR TITLE
added %ARCHITECTURE% to package name

### DIFF
--- a/Eclipse/Eclipse.install.recipe
+++ b/Eclipse/Eclipse.install.recipe
@@ -12,17 +12,12 @@
 		<string>Eclipse</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.pkg.Eclipse</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-			</dict>
 			<key>Processor</key>
 			<string>Installer</string>
 		</dict>

--- a/Eclipse/Eclipse.install.recipe
+++ b/Eclipse/Eclipse.install.recipe
@@ -12,7 +12,7 @@
 		<string>Eclipse</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.1</string>
+	<string>0.4.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.pkg.Eclipse</string>
 	<key>Process</key>

--- a/Eclipse/Eclipse.pkg.recipe
+++ b/Eclipse/Eclipse.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Eclipse IDE for Java Developers</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.1</string>
+	<string>0.2.8</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Eclipse</string>
 	<key>Process</key>
@@ -22,11 +22,84 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%ARCHITECTURE%-%version%.pkg</string>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 			</dict>
 			<key>Processor</key>
-			<string>AppPkgCreator</string>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications/Eclipse.app</string>
+				<key>overwrite</key>
+				<true/>
+				<key>source_path</key>
+				<string>%pathname%/Eclipse.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%pkgroot%/Applications/Eclipse.app</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleIdentifier</key>
+					<string>PKG_ID</string>
+					<key>CFBundleShortVersionString</key>
+					<string>version</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>group</key>
+							<string>admin</string>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+						<dict>
+							<key>group</key>
+							<string>admin</string>
+							<key>mode</key>
+							<string>755</string>
+							<key>path</key>
+							<string>Applications/Eclipse.app/Contents/MacOS/eclipse</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>%PKG_ID%</string>
+					<key>options</key>
+					<string>purge_ds_store</string>
+					<key>pkgdir</key>
+					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%ARCHITECTURE%-%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
 		</dict>
 	</array>
 </dict>

--- a/Eclipse/Eclipse.pkg.recipe
+++ b/Eclipse/Eclipse.pkg.recipe
@@ -95,7 +95,7 @@
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
+					<string>%NAME%-%ARCHITECTURE%-%version%</string>
 				</dict>
 			</dict>
 			<key>Processor</key>

--- a/Eclipse/Eclipse.pkg.recipe
+++ b/Eclipse/Eclipse.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Eclipse IDE for Java Developers</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.8</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.download.Eclipse</string>
 	<key>Process</key>
@@ -22,84 +22,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%ARCHITECTURE%-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Eclipse.app</string>
-				<key>overwrite</key>
-				<true/>
-				<key>source_path</key>
-				<string>%pathname%/Eclipse.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>info_path</key>
-				<string>%pkgroot%/Applications/Eclipse.app</string>
-				<key>plist_keys</key>
-				<dict>
-					<key>CFBundleIdentifier</key>
-					<string>PKG_ID</string>
-					<key>CFBundleShortVersionString</key>
-					<string>version</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PlistReader</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>mode</key>
-							<string>755</string>
-							<key>path</key>
-							<string>Applications/Eclipse.app/Contents/MacOS/eclipse</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgdir</key>
-					<string>%RECIPE_CACHE_DIR%</string>
-					<key>pkgname</key>
-					<string>%NAME%-%ARCHITECTURE%-%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
- added `%ARCHITECTURE%` to package name for differentiation
- removed redundant `%pkg_path%` definition from Eclipse.install.recipe