### PR TITLE
Numi - Switch to Sparkle Feed

### DIFF
--- a/Numi/Numi.download.recipe
+++ b/Numi/Numi.download.recipe
@@ -20,10 +20,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>appcast_url</key>
+				<string>https://s1.numi.app/update</string>
+			</dict>
+			<key>Processor</key>
+			<string>SparkleUpdateInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
-				<key>url</key>
-				<string>https://dl.devmate.com/com.dmitrynikolaev.numi/Numi.zip</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -38,7 +45,7 @@
 				<key>archive_path</key>
 				<string>%pathname%</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -49,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Numi.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Numi.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.dmitrynikolaev.numi" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4BT8G3UCSZ")</string>
 			</dict>
@@ -60,7 +67,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Numi.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Numi.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Numi/Numi.munki.recipe
+++ b/Numi/Numi.munki.recipe
@@ -44,7 +44,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>


### PR DESCRIPTION
Hi, @homebysix 

I've noticed that your download recipe downloads an old version for Numi from a static url:

```
autopkg run -v /Users/paul/Documents/GitHub/homebysix-recipes/Numi/Numi.munki.recipe 
Processing /Users/paul/Documents/GitHub/homebysix-recipes/Numi/Numi.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/homebysix-recipes/Numi/Numi.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 07 May 2019 04:48:09 GMT
URLDownloader: Storing new ETag header: "df8220dc33bc5b15eb10df5ed0026e98"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/downloads/Numi.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename Numi.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/downloads/Numi.zip to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Applications
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Applications/Numi.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Applications/Numi.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Applications/Numi.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Found version 3.20.2 in file /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Applications/Numi.app/Contents/Info.plist
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Applications at /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Numi/Numi-3.20.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Numi/Numi-3.20.2.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/receipts/Numi.munki-receipt-20221021-164627.plist

The following new items were downloaded:
    Download Path                                                                         
    -------------                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/downloads/Numi.zip  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                 Pkg Repo Path              Icon Repo Path  
    ----  -------  --------  ------------                 -------------              --------------  
    Numi  3.20.2   testing   apps/Numi/Numi-3.20.2.plist  apps/Numi/Numi-3.20.2.dmg
```

This PR switches the download recipe to use the Apps sparkle feed which does download the latest version:

```
autopkg run -v /Users/paul/Documents/GitHub/homebysix-recipes/Numi/Numi.munki.recipe 
Processing /Users/paul/Documents/GitHub/homebysix-recipes/Numi/Numi.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/homebysix-recipes/Numi/Numi.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
SparkleUpdateInfoProvider: Version retrieved from appcast: 704
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.30
SparkleUpdateInfoProvider: Found URL https://numi.sfo2.cdn.digitaloceanspaces.com/updates/3.30.704/Numi.zip
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/downloads/Numi-3.30.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename Numi-3.30.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/downloads/Numi-3.30.zip to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Numi.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Numi.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Numi.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Found version 3.30 in file /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi/Numi.app/Contents/Info.plist
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi at /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/Numi.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Numi/Numi-3.30.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Numi/Numi-3.30.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.Numi/receipts/Numi.munki-receipt-20221021-165011.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path               Pkg Repo Path            Icon Repo Path  
    ----  -------  --------  ------------               -------------            --------------  
    Numi  3.30     testing   apps/Numi/Numi-3.30.plist  apps/Numi/Numi-3.30.dmg
```

Thanks! 
