### PR TITLE
Td-Agent - Version + PLATFORM_ARCH Support

### DIFF
--- a/TreasureData/fluentd-tdagent.download.recipe
+++ b/TreasureData/fluentd-tdagent.download.recipe
@@ -3,13 +3,22 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the Treasure Data "td-agent" disk image, which is a stable distribution package for the fluentd-tdagent log collector (https://www.fluentd.org/faqs).</string>
+	<string>Downloads the Treasure Data "td-agent" disk image, which is a stable distribution package for the fluentd-tdagent log collector (https://www.fluentd.org/faqs).
+
+Acceptable values for PLATFORM_ARCH include:
+- 'x86_64': Downloads the Intel version of Td-Agent. (This is the default.)
+- 'arm64': Downloads the Apple Silicon version of Td-Agent.
+
+NOTE: The Intel build will function with Rosetta2, but separate packaging is
+ideal to support Apple Silicon Macs.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.fluentd-tdagent</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>tdagent</string>
+		<key>PLATFORM_ARCH</key>
+		<string>x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0</string>
@@ -19,11 +28,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>/macosx/td-agent-([\d\.-]+)\.dmg"</string>
+				<string>/macosx/td-agent-([\d\.-]+)\-%PLATFORM_ARCH%.dmg"</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 				<key>url</key>
-				<string>https://td-agent-package-browser.herokuapp.com/3/macosx</string>
+				<string>https://td-agent-package-browser.herokuapp.com/4/macosx</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -32,9 +41,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%PLATFORM_ARCH%.dmg</string>
 				<key>url</key>
-				<string>https://packages.treasuredata.com/3/macosx/td-agent-%version%.dmg</string>
+				<string>https://s3.amazonaws.com/packages.treasuredata.com/4/macosx/td-agent-%version%-%PLATFORM_ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/TreasureData/fluentd-tdagent.munki.recipe
+++ b/TreasureData/fluentd-tdagent.munki.recipe
@@ -3,7 +3,14 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the Treasure Data "td-agent" disk image, which is a stable distribution package for the tdagent log collector (https://www.fluentd.org/faqs), and imports the package into Munki.</string>
+	<string>Downloads the Treasure Data "td-agent" disk image, which is a stable distribution package for the tdagent log collector (https://www.fluentd.org/faqs), and imports the package into Munki.
+
+Acceptable values for PLATFORM_ARCH include:
+- 'x86_64': Downloads the Intel version of Td-Agent. (This is the default.)
+- 'arm64': Downloads the Apple Silicon version of Td-Agent.
+
+NOTE: The Intel build will function with Rosetta2, but separate packaging is
+ideal to support Apple Silicon Macs.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.fluentd-tdagent</string>
 	<key>Input</key>
@@ -12,6 +19,8 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>tdagent</string>
+		<key>PLATFORM_ARCH</key>
+		<string>x86_64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -26,6 +35,10 @@
 			<string>Fluentd (td-agent)</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%PLATFORM_ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/TreasureData/fluentd-tdagent.pkg.recipe
+++ b/TreasureData/fluentd-tdagent.pkg.recipe
@@ -20,6 +20,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%-%PLATFORM_ARCH%.pkg</string>
 				<key>source_pkg</key>
 				<string>%pathname%/*.pkg</string>
 			</dict>


### PR DESCRIPTION
This will leverage the latest version of Td-Agent (4) as well as support the different architectures for macOS.

Tests for default arch (x86_64):
```
➜  TreasureData git:(tdagent_updates) ✗ autopkg run -v ./fluentd-tdagent.munki.recipe -d .
Processing ./fluentd-tdagent.munki.recipe...
WARNING: ./fluentd-tdagent.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 4.4.2
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 04 Nov 2022 07:17:26 GMT
URLDownloader: Storing new ETag header: "029e154d3ae1d5f70454d6ee3d70e65c-3"
URLDownloader: Downloaded /Users/jramos/Library/AutoPkg/Cache/com.github.homebysix.munki.fluentd-tdagent/downloads/tdagent-x86_64.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/jramos/code/repos/munki-repo
MunkiImporter: Copied pkginfo to: /Users/jramos/code/repos/munki-repo/pkgsinfo/apps/tdagent/tdagent-4.4.2__1.plist
MunkiImporter:            pkg to: /Users/jramos/code/repos/munki-repo/pkgs/apps/tdagent/tdagent-x86_64-4.4.2.dmg
Receipt written to /Users/jramos/Library/AutoPkg/Cache/com.github.homebysix.munki.fluentd-tdagent/receipts/fluentd-tdagent.munki-receipt-20221111-155739.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/jramos/Library/AutoPkg/Cache/com.github.homebysix.munki.fluentd-tdagent/downloads/tdagent-x86_64.dmg

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                         Pkg Repo Path                          Icon Repo Path
    ----     -------  --------  ------------                         -------------                          --------------
    tdagent  4.4.2    testing   apps/tdagent/tdagent-4.4.2__1.plist  apps/tdagent/tdagent-x86_64-4.4.2.dmg
```

Tests using `-k` switch with `PLATFORM_ARCH=arm64` option.
```
➜  TreasureData git:(tdagent_updates) ✗ autopkg run -v ./fluentd-tdagent.munki.recipe -k PLATFORM_ARCH=arm64 -d .
Processing ./fluentd-tdagent.munki.recipe...
WARNING: ./fluentd-tdagent.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 4.4.2
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/jramos/Library/AutoPkg/Cache/com.github.homebysix.munki.fluentd-tdagent/downloads/tdagent-arm64.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/jramos/code/repos/munki-repo
MunkiImporter: Copied pkginfo to: /Users/jramos/code/repos/munki-repo/pkgsinfo/apps/tdagent/tdagent-4.4.2.plist
MunkiImporter:            pkg to: /Users/jramos/code/repos/munki-repo/pkgs/apps/tdagent/tdagent-arm64-4.4.2.dmg
Receipt written to /Users/jramos/Library/AutoPkg/Cache/com.github.homebysix.munki.fluentd-tdagent/receipts/fluentd-tdagent.munki-receipt-20221111-155509.plist

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                      Pkg Repo Path                         Icon Repo Path
    ----     -------  --------  ------------                      -------------                         --------------
    tdagent  4.4.2    testing   apps/tdagent/tdagent-4.4.2.plist  apps/tdagent/tdagent-arm64-4.4.2.dmg
```