### PR TITLE
FontFinagler: updated appcast_url, removed static minimum_os_version

### DIFF
--- a/FontFinagler/FontFinagler.download.recipe
+++ b/FontFinagler/FontFinagler.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>
-				<string>https://www.markdouma.com/fontfinagler/version.xml</string>
+				<string>https://www.markdouma.com/fontfinagler/version.php</string>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>

--- a/FontFinagler/FontFinagler.munki.recipe
+++ b/FontFinagler/FontFinagler.munki.recipe
@@ -26,8 +26,6 @@
 			<string>Mark Douma</string>
 			<key>display_name</key>
 			<string>Font Finagler</string>
-			<key>minimum_os_version</key>
-			<string>10.6</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
According to the developer, the appcast_url is no longer updated. Instead, information now goes to version.php and is backported to versionsSecure.xml (with the latter living in parent dir fontfinaglerl).

Omitting the static minimum_os_version outputs the right value.

Version 2.0 requires a new license if all features will be used.