### PR TITLE
Add scripts to DockerDesktop.munki.recipe

### DIFF
--- a/Docker/DockerDesktop.munki.recipe
+++ b/Docker/DockerDesktop.munki.recipe
@@ -28,6 +28,55 @@
 			<string>Docker</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/zsh
+
+currentUser="$(/usr/sbin/scutil &lt;&lt;&lt; "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ { print $3 }')"
+
+if	[ "${currentUser}" = "loginwindow" ]; then
+	echo "No user logged in, skipping Docker setup."
+	exit 1
+else
+	"/Applications/Docker.app/Contents/MacOS/install" --accept-license --user "${currentUser}"
+fi
+			</string>
+			<key>postuninstall_script</key>
+			<string>#!/bin/zsh
+
+/bin/launchctl bootout system /Library/LaunchDaemons/com.docker.socket.plist
+/bin/rm -f /Library/LaunchDaemons/com.docker.socket.plist
+/bin/rm -f /private/var/run/docker.sock
+
+/bin/rm -f /usr/local/bin/com.docker.cli
+/bin/rm -f /usr/local/bin/docker
+/bin/rm -f /usr/local/bin/docker-compose
+/bin/rm -f /usr/local/bin/docker-compose-v1
+/bin/rm -f /usr/local/bin/docker-credential-desktop
+/bin/rm -f /usr/local/bin/docker-credential-ecr-login
+/bin/rm -f /usr/local/bin/docker-credential-osxkeychain
+/bin/rm -f /usr/local/bin/docker-index
+/bin/rm -f /usr/local/bin/hub-tool
+/bin/rm -f /usr/local/bin/kubectl
+/bin/rm -f /usr/local/bin/kubectl-docker
+/bin/rm -f /usr/local/bin/vpnkit
+
+# These files are only installed if the user has tried to bind to a privileged port, they are not part of a default installation.
+if [ -f /Library/LaunchDaemons/com.docker.vmnetd.plist ]; then
+/bin/launchctl bootout system /Library/LaunchDaemons/com.docker.vmnetd.plist
+/bin/rm -f /Library/LaunchDaemons/com.docker.vmnetd.plist
+/bin/rm -f /Library/PrivilegedHelperTools/com.docker.vmnetd
+fi
+			</string>
+			<key>preinstall_script</key>
+			<string>#!/bin/zsh
+
+currentUser="$(/usr/sbin/scutil &lt;&lt;&lt; "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ { print $3 }')"
+
+if	[ "${currentUser}" = "loginwindow" ]; then
+	echo "No user logged in, skipping Docker install."
+	exit 1
+fi
+			</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
This PR adds three scripts:

- `preinstall_script` to skip installing Docker at the login window because the command line options need to run as a user. (Remove this for scenarios where you want installs to happen at the login window.)
- `postinstall_script` to run the new command line install options from Docker Desktop 4.15. Execution is skipped at the login window.
- `postuninstall_script` to cleanup the items that Docker Desktop installs. (Lines 50-61 could be condensed into a `for` loop but I left them this way as I think it makes it easier to read for anyone without scripting experience.)