### PR TITLE
Update Eclipse.download.recipe

### DIFF
--- a/Eclipse/Eclipse.download.recipe
+++ b/Eclipse/Eclipse.download.recipe
@@ -97,7 +97,7 @@ Intel ("x86_64") or Apple Silicon ("aarch64") version of Eclipse.</string>
 				<key>input_path</key>
 				<string>%pathname%/*.app</string>
 				<key>requirement</key>
-				<string>identifier "org.eclipse.platform.ide" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JCDTMS22B4</string>
+				<string>anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JCDTMS22B4</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Hi, @homebysix 

This is a new PR that removes the checking of the identifier from CodeSignatureVerifier. 

This keeps the recipes existing optional download functionality, and would resolve https://github.com/autopkg/homebysix-recipes/issues/554

I've tested all the download options and they complete with no issues. I'll only post the output from the default options. 

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/homebysix-recipes/Eclipse/Eclipse.download.recipe
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/Eclipse/Eclipse.download.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/Eclipse/Eclipse.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
OptionSelector
{'Input': {'options': {'Eclipse IDE for Automotive Software Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-automotive[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for C/C++ Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-cpp[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Eclipse Committers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-committers[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-java[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java EE Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-jee[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java and DSL Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-dsl[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse IDE for Java and Report Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-reporting[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse Modeling Tools': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-modeling[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for PHP Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-php[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for Parallel Application Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-parallel[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for RCP and RAP Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-rcp[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for Scout Developers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-scout[\\w-]+macosx-cocoa-x86_64\\.dmg)',
                       'Eclipse for Testers': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-testing[\\w-]+macosx-cocoa-x86_64\\.dmg)'},
           'selection': 'Eclipse IDE for Java Developers'}}
OptionSelector: No value supplied for result_output_var_name, setting default value of: selection
OptionSelector: Selection 'Eclipse IDE for Java Developers': '\/downloads\/download\.php\?file=([/\w-]+eclipse-java[\w-]+macosx-cocoa-x86_64\.dmg)'
{'Output': {'selection': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-java[\\w-]+macosx-cocoa-x86_64\\.dmg)'}}
URLTextSearcher
{'Input': {'re_pattern': '\\/downloads\\/download\\.php\\?file=([/\\w-]+eclipse-java[\\w-]+macosx-cocoa-x86_64\\.dmg)',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11) '
                                             'AppleWebKit/601.1.39 (KHTML, '
                                             'like Gecko) Version/9.0 '
                                             'Safari/601.1.39'},
           'result_output_var_name': 'match',
           'url': 'https://eclipse.org/downloads/eclipse-packages/'}}
URLTextSearcher: Found matching text (match): /technology/epp/downloads/release/2022-12/R/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg
{'Output': {'match': '/technology/epp/downloads/release/2022-12/R/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg'}}
URLDownloader
{'Input': {'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_11) '
                                             'AppleWebKit/601.1.39 (KHTML, '
                                             'like Gecko) Version/9.0 '
                                             'Safari/601.1.39'},
           'url': 'https://eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2022-12/R/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 05 Dec 2022 21:30:32 GMT
URLDownloader: Storing new ETag header: "638e62f8-12f73d3b"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/downloads/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg
{'Output': {'download_changed': True,
            'etag': '"638e62f8-12f73d3b"',
            'last_modified': 'Mon, 05 Dec 2022 21:30:32 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/downloads/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/downloads/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/downloads/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg/*.app',
           'requirement': 'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JCDTMS22B4'}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/downloads/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.9Tb6r0/Eclipse.app' matched from globbed '/private/tmp/dmg.9Tb6r0/*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9Tb6r0/Eclipse.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9Tb6r0/Eclipse.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9Tb6r0/Eclipse.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/receipts/Eclipse.download-receipt-20221221-120312.plist

The following new items were downloaded:
    Download Path                                                                                                                     
    -------------                                                                                                                     
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.download.Eclipse/downloads/eclipse-java-2022-12-R-macosx-cocoa-x86_64.dmg 
```