### PR TITLE
Capture version in initial URLTextSearcher step

### DIFF
--- a/MySQLWorkbench/MySQLWorkbench.download.recipe
+++ b/MySQLWorkbench/MySQLWorkbench.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;dmg&gt;mysql-workbench-community-\S+dmg)</string>
+				<string>(?P&lt;dmg&gt;mysql-workbench-community-(?P&lt;version&gt;[\d.]+)-\S+dmg)</string>
 				<key>request_headers</key>
 				<dict>
 					<key>user-agent</key>

--- a/MySQLWorkbench/MySQLWorkbench.pkg.recipe
+++ b/MySQLWorkbench/MySQLWorkbench.pkg.recipe
@@ -18,24 +18,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>mysql-workbench-community-([\d.]+)-\S+dmg</string>
-				<key>request_headers</key>
-				<dict>
-					<key>user-agent</key>
-					<string>%USER_AGENT%</string>
-				</dict>
-				<key>result_output_var_name</key>
-				<string>version</string>
-				<key>url</key>
-				<string>http://dev.mysql.com/downloads/workbench</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>


### PR DESCRIPTION
The `URLTextSearcher` step in the `pkg` recipe has been failing for me.  I'm assuming it's due to the URL being different (no `s` in `http`).

But the simpler solution to me would be to just grab the version during the `URLTextSearcher` step in the `download` recipe instead.

```python

[...]
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.MySQLWorkbench/downloads/MySQL '
                         'Workbench.dmg/MySQLWorkbench.app',
           'requirement': 'identifier "com.oracle.workbench.MySQLWorkbench" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'VB5E2TV963'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.MySQLWorkbench/downloads/MySQL Workbench.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.YCCZn7/MySQLWorkbench.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.YCCZn7/MySQLWorkbench.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.YCCZn7/MySQLWorkbench.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'mysql-workbench-community-([\\d.]+)-\\S+dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_12_6) '
                                             'AppleWebKit/603.3.8 (KHTML, like '
                                             'Gecko) Version/10.1.2 '
                                             'Safari/603.3.8'},
           'result_output_var_name': 'version',
           'url': 'http://dev.mysql.com/downloads/workbench'}}
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Library/AutoPkg/autopkglib/URLTextSearcher.py", line 122, in main
    groupmatch, groupdict = self.re_search(content)
  File "/Library/AutoPkg/autopkglib/URLTextSearcher.py", line 109, in re_search
    raise ProcessorError(f"{NO_MATCH_MESSAGE}: {self.env['url']}")
autopkglib.ProcessorError: No match found on URL: http://dev.mysql.com/downloads/workbench
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
No match found on URL: http://dev.mysql.com/downloads/workbench
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.MySQLWorkbench/receipts/com.github.homebysix.pkg.MySQLWorkbench-receipt-20230102-163700.plist

The following recipes failed:
    com.github.homebysix.pkg.MySQLWorkbench
        Error in com.github.homebysix.pkg.MySQLWorkbench: Processor: URLTextSearcher: Error: No match found on URL: http://dev.mysql.com/downloads/workbench
```