### PR TITLE
Update ParallelsDesktop.munki.recipe

### DIFF
--- a/DuetDisplay/duet.download.recipe
+++ b/DuetDisplay/duet.download.recipe
@@ -5,13 +5,19 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of duet.</string>
+	<string>Downloads the latest version of duet.
+
+To download the latest version of duet (macOS 12.3 and above) set DOWNLOAD_VERSION to "3"
+
+To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_VERSION to "2"</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.duet</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>duet</string>
+		<key>DOWNLOAD_VERSION</key>
+		<string>3</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -20,17 +26,23 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://updates.duetdisplay.com/checkMacUpdates</string>
+				<key>re_pattern</key>
+				<string>(https://duetdownload\.com/Mac/%DOWNLOAD_VERSION%_[0-9]+/duet-([0-9]+(-[0-9]+)+)\.zip)</string>
+				<key>result_output_var_name</key>
+				<string>DOWNLOAD_URL</string>
+				<key>url</key>
+				<string>https://www.duetdisplay.com/#download</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
+				<string>%NAME%.zip</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/DuetDisplay/duet.munki.recipe
+++ b/DuetDisplay/duet.munki.recipe
@@ -5,7 +5,9 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of duet and imports it into Munki.</string>
+	<string>Downloads the latest version of duet and imports it into Munki.
+
+If downloading the latest legacy version of duet (macOS 10.9 - 12.2) set maximum_os_version to 12.2 otherwise please leave blank.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.duet</string>
 	<key>Input</key>
@@ -28,6 +30,8 @@
 			<string>duet</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>maximum_os_version</key>
+			<string></string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -11,11 +11,15 @@ For major version 16, set the PLATFORM_ARCH in your override to either "intel" o
 
 For major version 17, set the PLATFORM_ARCH in your override to "image"
 
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
+
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.ParallelsDesktop</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
@@ -32,14 +36,12 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 			<string>Parallels, Inc.</string>
 			<key>display_name</key>
 			<string>Parallels Desktop</string>
-			<key>minimum_os_version</key>
-			<string>10.10</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>preuninstall_script</key>
 			<string>#!/bin/bash
 if [ -f /usr/local/bin/prlsrvctl ]; then
-    /usr/local/bin/prlsrvctl deactivate-license
+	/usr/local/bin/prlsrvctl deactivate-license
 fi
 exit 0
 </string>
@@ -56,14 +58,14 @@ lib_files="/Library/Parallels/"
 
 if [ -d "${app_Bundle}" ]
 then
-    /bin/echo "Found ${app_Bundle}, removing..."
-    /bin/rm -rf "${app_Bundle}"
+	/bin/echo "Found ${app_Bundle}, removing..."
+	/bin/rm -rf "${app_Bundle}"
 fi
 
 if [ -d "${lib_files}" ]
 then
-    /bin/echo "Found ${lib_files}, removing..."
-    /bin/rm -rf "${lib_files}"
+	/bin/echo "Found ${lib_files}, removing..."
+	/bin/rm -rf "${lib_files}"
 fi
 
 # Remove the pkg receipt
@@ -75,7 +77,7 @@ pkgutil --forget "${pkgReceipt}"
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.pkg.ParallelsDesktop</string>
 	<key>Process</key>
@@ -102,6 +104,8 @@ pkgutil --forget "${pkgReceipt}"
 				<array>
 					<string>/Applications/Parallels Desktop.app</string>
 				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>


### PR DESCRIPTION
Hi, @homebysix 

The ParallelsDesktop Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist. Instead `minimum_os_version` is hardcoded to a value of 10.10

This PR 

- Adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the `minimum_os_version` becomes 10.12.6. 
- Converts spaces to tabs

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/homebysix-recipes/Parallels/ParallelsDesktop.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/Parallels/ParallelsDesktop.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/Parallels/ParallelsDesktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 01 Oct 2020 07:06:54 GMT
URLDownloader: Storing new ETag header: "5f75800e-c8e302b"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PLOx9R/Parallels Desktop.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PLOx9R/Parallels Desktop.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PLOx9R/Parallels Desktop.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg
Versioner: Found version 15.1.5 in file /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg/Parallels Desktop.app/Contents/Info.plist
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/pkgroot
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Scripts
Copier
Copier: Copied /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Scripts/Parallels Desktop.dmg
FileCreator
FileCreator: Created file at /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Scripts/postinstall
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/pkgroot
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Scripts
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg
Copier: Copied /private/tmp/dmg.Uz1E2J/Parallels Desktop.app to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Parallels Desktop/Applications/Parallels Desktop.app
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Parallels Desktop.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.12.6
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.parallels.desktop.console', 'CFBundleName': 'Parallels Desktop', 'CFBundleShortVersionString': '15.1.5', 'CFBundleVersion': '47309', 'minosversion': '10.12.6', 'path': '/Applications/Parallels Desktop.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.12.6'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Parallels Desktop/Parallels Desktop-15.1.5__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Parallels Desktop/Parallels Desktop-15.1.5__1.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Parallels Desktop
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/receipts/ParallelsDesktop.munki-receipt-20230116-163048.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/downloads/Parallels Desktop-15.dmg  

The following packages were built:
    Identifier                       Version  Pkg Path                                                                                                    
    ----------                       -------  --------                                                                                                    
    com.parallels.desktop.installer  15.1.5   /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.ParallelsDesktop/Parallels Desktop-15.1.5.pkg  

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                              Pkg Repo Path                                           Icon Repo Path  
    ----               -------  --------  ------------                                              -------------                                           --------------  
    Parallels Desktop  15.1.5   testing   apps/Parallels Desktop/Parallels Desktop-15.1.5__1.plist  apps/Parallels Desktop/Parallels Desktop-15.1.5__1.pkg
```

