### PR TITLE
Update duet.download.recipe

### DIFF
--- a/DuetDisplay/duet.download.recipe
+++ b/DuetDisplay/duet.download.recipe
@@ -7,9 +7,9 @@
 	<key>Description</key>
 	<string>Downloads the latest version of duet.
 
-To download the latest version of duet (macOS 12.3 and above) set DOWNLOAD_VERSION to "3"
+To download the latest version of duet (macOS 12.3 and above) set DOWNLOAD_VERSION to "AppleSilicon" - Please note the "AppleSilicon" version is Universal.
 
-To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_VERSION to "2"</string>
+To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_VERSION to "legacyMac"</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.duet</string>
 	<key>Input</key>
@@ -17,7 +17,7 @@ To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_V
 		<key>NAME</key>
 		<string>duet</string>
 		<key>DOWNLOAD_VERSION</key>
-		<string>3</string>
+		<string>AppleSilicon</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -26,23 +26,10 @@ To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_V
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>(https://duetdownload\.com/Mac/%DOWNLOAD_VERSION%_[0-9]+/duet-([0-9]+(-[0-9]+)+)\.zip)</string>
-				<key>result_output_var_name</key>
-				<string>DOWNLOAD_URL</string>
-				<key>url</key>
-				<string>https://www.duetdisplay.com/#download</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://updates.duetdisplay.com/%DOWNLOAD_VERSION%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @homebysix 

duet has made a change to the download URLs. There are now static URLS for each download track. 

- https://updates.duetdisplay.com/AppleSilicon which is for the latest universal app. 
- https://updates.duetdisplay.com/legacyMac which is of the latest legacy app. 

This PR 
- Removes `URLTextSearcher`
- Updates the Download URL
- Updates the `DOWNLOAD_VERSION` variable. Overrides will need to be updated to use `AppleSilicon` or `legacyMac`

-vv Output from AppleSilicon:

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/homebysix-recipes/DuetDisplay/duet.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/DuetDisplay/duet.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/DuetDisplay/duet.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'duet.zip',
           'url': 'https://updates.duetdisplay.com/AppleSilicon'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 20 Feb 2023 18:34:29 GMT
URLDownloader: Storing new ETag header: "84115abe157f215d0b198d18454ed312"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip
{'Output': {'download_changed': True,
            'etag': '"84115abe157f215d0b198d18454ed312"',
            'last_modified': 'Mon, 20 Feb 2023 18:34:29 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip',
           'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename duet.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.kairos.duetMac" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = J6L96W8A86)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet.dmg',
           'dmg_root': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications'}}
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications at /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Use your iPad as an external display.',
                       'developer': 'Rahul Dewan',
                       'display_name': 'duet',
                       'maximum_os_version': '',
                       'name': 'duet',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/duet'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/duet/duet-3.3.0.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/duet/duet-3.3.0.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'duet',
                                                       'pkg_repo_path': 'apps/duet/duet-3.3.0.0.dmg',
                                                       'pkginfo_path': 'apps/duet/duet-3.3.0.0.plist',
                                                       'version': '3.3.0.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2023, 2, 23, 13, 57, 27),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '13.2.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Use your iPad as an external '
                                          'display.',
                           'developer': 'Rahul Dewan',
                           'display_name': 'duet',
                           'installer_item_hash': 'a14be036ee0494a355a0754bc04ef8840bcdf01162bde732881103902dad5f29',
                           'installer_item_location': 'apps/duet/duet-3.3.0.0.dmg',
                           'installer_item_size': 15175,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.kairos.duetMac',
                                         'CFBundleName': 'duet',
                                         'CFBundleShortVersionString': '3.3.0.0',
                                         'CFBundleVersion': '3.3.0.0',
                                         'minosversion': '12.0',
                                         'path': '/Applications/duet.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'duet.app'}],
                           'maximum_os_version': '',
                           'minimum_os_version': '12.0',
                           'name': 'duet',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.3.0.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/duet/duet-3.3.0.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/duet/duet-3.3.0.0.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/receipts/duet.munki-receipt-20230223-135727.plist

The following new items were downloaded:
    Download Path                                                                         
    -------------                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                  Pkg Repo Path               Icon Repo Path  
    ----  -------  --------  ------------                  -------------               --------------  
    duet  3.3.0.0  testing   apps/duet/duet-3.3.0.0.plist  apps/duet/duet-3.3.0.0.dmg
```

-vv Output from  legacyMac

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/homebysix-recipes/DuetDisplay/duet.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/DuetDisplay/duet.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/DuetDisplay/duet.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'duet.zip',
           'url': 'https://updates.duetdisplay.com/legacyMac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 30 Jan 2023 21:46:31 GMT
URLDownloader: Storing new ETag header: "45ce0022b21462c09c44a42dac59497e"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip
{'Output': {'download_changed': True,
            'etag': '"45ce0022b21462c09c44a42dac59497e"',
            'last_modified': 'Mon, 30 Jan 2023 21:46:31 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip',
           'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename duet.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.kairos.duetMac" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = J6L96W8A86)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications/duet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet.dmg',
           'dmg_root': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications'}}
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet/Applications at /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/duet.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Use your iPad as an external display.',
                       'developer': 'Rahul Dewan',
                       'display_name': 'duet',
                       'maximum_os_version': '',
                       'name': 'duet',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/duet'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/duet/duet-2.4.7.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/duet/duet-2.4.7.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'duet',
                                                       'pkg_repo_path': 'apps/duet/duet-2.4.7.1.dmg',
                                                       'pkginfo_path': 'apps/duet/duet-2.4.7.1.plist',
                                                       'version': '2.4.7.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2023, 2, 23, 13, 58, 29),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '13.2.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Use your iPad as an external '
                                          'display.',
                           'developer': 'Rahul Dewan',
                           'display_name': 'duet',
                           'installer_item_hash': '0fd47da340e7ac98dbcf2355522da70614348630dd87464a62e2d5a04d58836b',
                           'installer_item_location': 'apps/duet/duet-2.4.7.1.dmg',
                           'installer_item_size': 28848,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.kairos.duetMac',
                                         'CFBundleName': 'duet',
                                         'CFBundleShortVersionString': '2.4.7.1',
                                         'CFBundleVersion': '2.4.7.1',
                                         'minosversion': '10.13',
                                         'path': '/Applications/duet.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'duet.app'}],
                           'maximum_os_version': '',
                           'minimum_os_version': '10.13',
                           'name': 'duet',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.4.7.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/duet/duet-2.4.7.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/duet/duet-2.4.7.1.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/receipts/duet.munki-receipt-20230223-135829.plist

The following new items were downloaded:
    Download Path                                                                         
    -------------                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.zip  

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                  Pkg Repo Path               Icon Repo Path  
    ----  -------  --------  ------------                  -------------               --------------  
    duet  2.4.7.1  testing   apps/duet/duet-2.4.7.1.plist  apps/duet/duet-2.4.7.1.dmg
```