### PR TITLE
Update TunnelBear.download.recipe

### DIFF
--- a/TunnelBear/TunnelBear.download.recipe
+++ b/TunnelBear/TunnelBear.download.recipe
@@ -20,17 +20,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://s3.amazonaws.com/tunnelbear/downloads/mac/appcast.xml</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
+				<string>%NAME%.zip</string>
+				<key>url</key>
+				<string>https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @homebysix 

TunnelBears Sparkle Feed isn't listing the latest version of the app (Version 5)

```
curl https://s3.amazonaws.com/tunnelbear/downloads/mac/appcast.xml
<?xml version="1.0" standalone="yes"?>
<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
    <channel>
        <title>TunnelBear</title>
        <item>
            <title>4.1.8</title>
            <pubDate>Tue, 31 May 2022 10:06:59 -0400</pubDate>
            <sparkle:version>1629989300</sparkle:version>
            <sparkle:shortVersionString>4.1.8</sparkle:shortVersionString>
            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
            <enclosure
              url="https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-4.1.8.zip"
              length="33737494"
              type="application/octet-stream"
            />
        </item>
        <item>
            <title>4.9.9</title>
            <pubDate>Wed, 01 Jun 2022 13:31:13 -0400</pubDate>
            <sparkle:version>499</sparkle:version>
            <sparkle:shortVersionString>4.9.9</sparkle:shortVersionString>
            <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
            <enclosure
              url="https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-4.9.9.zip"
              length="38716610"
              type="application/octet-stream"
              sparkle:edSignature="sLrfK4t/0UN/qmzsHYfP8S0v1591mRpo8BLejpR8VPC9/d/T0sesPKsYcqDwW0yPcY5sJHi2umcwbRcq7qNMBw=="
            />
            <sparkle:deltas>
                <enclosure url="//TunnelBear-4.9.9499-498.delta"
                  sparkle:deltaFrom="498"
                  length="30042"
                  type="application/octet-stream"
                  sparkle:edSignature="4NxtlQAwub/PgBrHLhEWjHI5a0KFGxnPgmndxN1KfK/e+gxcQLrQIkbSUBdnysINMnb5j3qkKuChrhL63/oeDA=="
                />
            </sparkle:deltas>
        </item>
        <item>
            <title>4.9.8</title>
            <pubDate>Wed, 01 Jun 2022 13:30:54 -0400</pubDate>
            <sparkle:version>498</sparkle:version>
            <sparkle:shortVersionString>4.9.8</sparkle:shortVersionString>
            <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
            <enclosure
              url="https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-4.9.8.zip"
              length="38716616"
              type="application/octet-stream"
              sparkle:edSignature="K52wSSRxo9JekVDo+YUvI6F73gN9A8AFINm4k/ny2fcwT1RBSfeo98jVrteyxlQ8cG5rR6PBDg5eFtNwKUxJDQ=="/>
        </item>
    </channel>
</rss>
```

This PR switches from the Sparkle Feed to a static URL.

Output from a successful run 

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/homebysix-recipes/TunnelBear/TunnelBear.munki.recipe
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/TunnelBear/TunnelBear.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/TunnelBear/TunnelBear.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 11 Apr 2023 15:21:12 GMT
URLDownloader: Storing new ETag header: "b0970bbdc7580a5ba17584bee134ada3-3"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/downloads/TunnelBear.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename TunnelBear.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/downloads/TunnelBear.zip to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/TunnelBear/Applications
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/TunnelBear/Applications/TunnelBear.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/TunnelBear/Applications/TunnelBear.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/TunnelBear/Applications/TunnelBear.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/TunnelBear/Applications at /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/TunnelBear.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/TunnelBear/TunnelBear-5.0.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/TunnelBear/TunnelBear-5.0.1.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/receipts/TunnelBear.munki-receipt-20230425-112346.plist

The following new items were downloaded:
    Download Path                                                                                     
    -------------                                                                                     
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.TunnelBear/downloads/TunnelBear.zip  

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                            Pkg Repo Path                         Icon Repo Path  
    ----        -------  --------  ------------                            -------------                         --------------  
    TunnelBear  5.0.1    testing   apps/TunnelBear/TunnelBear-5.0.1.plist  apps/TunnelBear/TunnelBear-5.0.1.dmg
```