### PR TITLE
Update AdobeDNGConverter.munki.recipe

### DIFF
--- a/Adobe/AdobeDNGConverter.munki.recipe
+++ b/Adobe/AdobeDNGConverter.munki.recipe
@@ -45,6 +45,31 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>re_pattern</key>
+				<string>os-version min=\"([0-9]*\.[0-9]+)\"</string>
+				<key>result_output_var_name</key>
+				<string>min_os_ver</string>
+				<key>url</key>
+				<string>file://localhost/%RECIPE_CACHE_DIR%/unpack/Distribution</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			 <key>Arguments</key>
+			 <dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>minimum_os_version</key>
+					<string>%min_os_ver%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
 					<key>version</key>
@@ -81,6 +106,18 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @homebysix 

Currently the AdobeDNGConverter recipe sets the default minimum os version for packages (10.5.0). 

However the current minimum OS version is 11 https://helpx.adobe.com/camera-raw/using/adobe-dng-converter.html 

This PR 
- Adds URLTextSearcher to grab the minimum OS version from pkg Distribution file.
- Adds PathDeleter to tidy up unpacking steps

Output from a successful run

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/homebysix-recipes/Adobe/AdobeDNGConverter.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/Adobe/AdobeDNGConverter.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/homebysix-recipes/Adobe/AdobeDNGConverter.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'DNG Converter.dmg',
           'url': 'https://www.adobe.com/go/dng_converter_mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 13 Apr 2023 05:33:39 GMT
URLDownloader: Storing new ETag header: "4865b23c-5f931111732c0"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG Converter.dmg
{'Output': {'download_changed': True,
            'etag': '"4865b23c-5f931111732c0"',
            'last_modified': 'Thu, 13 Apr 2023 05:33:39 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG '
                        'Converter.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG '
                                                                        'Converter.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FileFinder
{'Input': {'pattern': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG '
                      'Converter.dmg/*.pkg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG Converter.dmg
FileFinder: Found file match: '/private/tmp/dmg.8WjK88/DNGConverter_15_3.pkg' from globbed '/private/tmp/dmg.8WjK88/*.pkg'
FileFinder: DMG-relative file match: 'DNGConverter_15_3.pkg'
FileFinder: Basename match: 'DNGConverter_15_3.pkg'
{'Output': {'dmg_found_filename': 'DNGConverter_15_3.pkg',
            'found_basename': 'DNGConverter_15_3.pkg',
            'found_filename': '/private/tmp/dmg.8WjK88/DNGConverter_15_3.pkg'}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Adobe Inc. '
                                        '(JQ525L2MZD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG '
                         'Converter.dmg/DNGConverter_15_3.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG Converter.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "DNGConverter_15_3.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-04-07 10:32:56 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Inc. (JQ525L2MZD)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            97 9A 81 BE 07 15 BA 87 99 0E AD DC AE 97 A7 98 08 19 8A 1E DE 0F 
CodeSignatureVerifier:            4A 42 0D CE 38 96 80 A1 CE BF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack',
           'flat_pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG '
                            'Converter.dmg/DNGConverter_15_3.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG Converter.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.OMtbuW/DNGConverter_15_3.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG '
                               'Converter/Applications',
           'pkg_payload_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack/DNGConverter.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack/DNGConverter.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG Converter/Applications
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG '
                               'Converter/Applications/Adobe DNG '
                               'Converter.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 15.3 (1451) in file /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG Converter/Applications/Adobe DNG Converter.app/Contents/Info.plist
{'Output': {'version': '15.3 (1451)'}}
URLTextSearcher
{'Input': {'re_pattern': 'os-version min=\\"([0-9]*\\.[0-9]+)\\"',
           'result_output_var_name': 'min_os_ver',
           'url': 'file://localhost//Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack/Distribution'}}
URLTextSearcher: Found matching text (min_os_ver): 11.0
{'Output': {'min_os_ver': '11.0'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'minimum_os_version': '11.0'},
           'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                       'catalogs': ['testing'],
                       'description': 'The Adobe DNG Converter is a free '
                                      'utility that enables you to easily '
                                      'convert camera-specific raw files from '
                                      'more than 600 cameras to the more '
                                      'universal DNG raw format.',
                       'developer': 'Adobe',
                       'display_name': 'DNG Converter',
                       'name': 'DNG Converter',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'minimum_os_version': '11.0'} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                        'catalogs': ['testing'],
                        'description': 'The Adobe DNG Converter is a free '
                                       'utility that enables you to easily '
                                       'convert camera-specific raw files from '
                                       'more than 600 cameras to the more '
                                       'universal DNG raw format.',
                        'developer': 'Adobe',
                        'display_name': 'DNG Converter',
                        'minimum_os_version': '11.0',
                        'name': 'DNG Converter',
                        'unattended_install': True}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '15.3 (1451)'},
           'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                       'catalogs': ['testing'],
                       'description': 'The Adobe DNG Converter is a free '
                                      'utility that enables you to easily '
                                      'convert camera-specific raw files from '
                                      'more than 600 cameras to the more '
                                      'universal DNG raw format.',
                       'developer': 'Adobe',
                       'display_name': 'DNG Converter',
                       'minimum_os_version': '11.0',
                       'name': 'DNG Converter',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '15.3 (1451)'} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                        'catalogs': ['testing'],
                        'description': 'The Adobe DNG Converter is a free '
                                       'utility that enables you to easily '
                                       'convert camera-specific raw files from '
                                       'more than 600 cameras to the more '
                                       'universal DNG raw format.',
                        'developer': 'Adobe',
                        'display_name': 'DNG Converter',
                        'minimum_os_version': '11.0',
                        'name': 'DNG Converter',
                        'unattended_install': True,
                        'version': '15.3 (1451)'}}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG '
                        'Converter',
           'installs_item_paths': ['/Applications/Adobe DNG Converter.app']}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Adobe DNG Converter.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.adobe.DNGConverter',
                                                 'CFBundleName': 'DNG '
                                                                 'Converter',
                                                 'CFBundleShortVersionString': '15.3 '
                                                                               '(1451)',
                                                 'CFBundleVersion': '15.3f1451',
                                                 'minosversion': '10.3.9',
                                                 'path': '/Applications/Adobe '
                                                         'DNG Converter.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}],
                                   'version': '15.3 (1451)'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.adobe.DNGConverter',
                                                'CFBundleName': 'DNG Converter',
                                                'CFBundleShortVersionString': '15.3 '
                                                                              '(1451)',
                                                'CFBundleVersion': '15.3f1451',
                                                'minosversion': '10.3.9',
                                                'path': '/Applications/Adobe '
                                                        'DNG Converter.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}],
                                  'version': '15.3 (1451)'},
           'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                       'catalogs': ['testing'],
                       'description': 'The Adobe DNG Converter is a free '
                                      'utility that enables you to easily '
                                      'convert camera-specific raw files from '
                                      'more than 600 cameras to the more '
                                      'universal DNG raw format.',
                       'developer': 'Adobe',
                       'display_name': 'DNG Converter',
                       'minimum_os_version': '11.0',
                       'name': 'DNG Converter',
                       'unattended_install': True,
                       'version': '15.3 (1451)'}}}
MunkiPkginfoMerger: Merged {'version': '15.3 (1451)', 'installs': [{'CFBundleIdentifier': 'com.adobe.DNGConverter', 'CFBundleName': 'DNG Converter', 'CFBundleShortVersionString': '15.3 (1451)', 'CFBundleVersion': '15.3f1451', 'minosversion': '10.3.9', 'path': '/Applications/Adobe DNG Converter.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                        'catalogs': ['testing'],
                        'description': 'The Adobe DNG Converter is a free '
                                       'utility that enables you to easily '
                                       'convert camera-specific raw files from '
                                       'more than 600 cameras to the more '
                                       'universal DNG raw format.',
                        'developer': 'Adobe',
                        'display_name': 'DNG Converter',
                        'installs': [{'CFBundleIdentifier': 'com.adobe.DNGConverter',
                                      'CFBundleName': 'DNG Converter',
                                      'CFBundleShortVersionString': '15.3 '
                                                                    '(1451)',
                                      'CFBundleVersion': '15.3f1451',
                                      'minosversion': '10.3.9',
                                      'path': '/Applications/Adobe DNG '
                                              'Converter.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '11.0',
                        'name': 'DNG Converter',
                        'unattended_install': True,
                        'version': '15.3 (1451)'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG '
                       'Converter.dmg',
           'pkginfo': {'blocking_applications': ['Adobe DNG Converter.app'],
                       'catalogs': ['testing'],
                       'description': 'The Adobe DNG Converter is a free '
                                      'utility that enables you to easily '
                                      'convert camera-specific raw files from '
                                      'more than 600 cameras to the more '
                                      'universal DNG raw format.',
                       'developer': 'Adobe',
                       'display_name': 'DNG Converter',
                       'installs': [{'CFBundleIdentifier': 'com.adobe.DNGConverter',
                                     'CFBundleName': 'DNG Converter',
                                     'CFBundleShortVersionString': '15.3 '
                                                                   '(1451)',
                                     'CFBundleVersion': '15.3f1451',
                                     'minosversion': '10.3.9',
                                     'path': '/Applications/Adobe DNG '
                                             'Converter.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '11.0',
                       'name': 'DNG Converter',
                       'unattended_install': True,
                       'version': '15.3 (1451)'},
           'repo_subdirectory': 'apps/DNG Converter'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/DNG Converter/DNG Converter-15.3 (1451).plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/DNG Converter/DNG Converter-15.3 (1451).dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'DNG Converter',
                                                       'pkg_repo_path': 'apps/DNG '
                                                                        'Converter/DNG '
                                                                        'Converter-15.3 '
                                                                        '(1451).dmg',
                                                       'pkginfo_path': 'apps/DNG '
                                                                       'Converter/DNG '
                                                                       'Converter-15.3 '
                                                                       '(1451).plist',
                                                       'version': '15.3 '
                                                                  '(1451)'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2023, 5, 10, 12, 11, 58),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '13.3.1'},
                           'autoremove': False,
                           'blocking_applications': ['Adobe DNG Converter.app'],
                           'catalogs': ['testing'],
                           'description': 'The Adobe DNG Converter is a free '
                                          'utility that enables you to easily '
                                          'convert camera-specific raw files '
                                          'from more than 600 cameras to the '
                                          'more universal DNG raw format.',
                           'developer': 'Adobe',
                           'display_name': 'DNG Converter',
                           'installed_size': 1918708,
                           'installer_item_hash': '76357d656f84ecdf4965536774160efbcc271013965069afeb21b50245ea6a6e',
                           'installer_item_location': 'apps/DNG Converter/DNG '
                                                      'Converter-15.3 '
                                                      '(1451).dmg',
                           'installer_item_size': 1186156,
                           'installs': [{'CFBundleIdentifier': 'com.adobe.DNGConverter',
                                         'CFBundleName': 'DNG Converter',
                                         'CFBundleShortVersionString': '15.3 '
                                                                       '(1451)',
                                         'CFBundleVersion': '15.3f1451',
                                         'minosversion': '10.3.9',
                                         'path': '/Applications/Adobe DNG '
                                                 'Converter.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '11.0',
                           'name': 'DNG Converter',
                           'receipts': [{'installed_size': 324842,
                                         'packageid': 'com.adobe.DNGConverter',
                                         'version': '0'},
                                        {'installed_size': 1593866,
                                         'packageid': 'com.adobe.CameraRawProfiles',
                                         'version': '0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '15.3 (1451)'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/DNG '
                             'Converter/DNG Converter-15.3 (1451).dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/DNG '
                                 'Converter/DNG Converter-15.3 (1451).plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack',
                         '/Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG '
                         'Converter']}}
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/DNG Converter
{'Output': {}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/receipts/AdobeDNGConverter.munki-receipt-20230510-131200.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/paul/Library/AutoPkg/Cache/com.github.homebysix.munki.DNGConverter/downloads/DNG Converter.dmg  

The following new items were imported into Munki:
    Name           Version      Catalogs  Pkginfo Path                                        Pkg Repo Path                                     Icon Repo Path  
    ----           -------      --------  ------------                                        -------------                                     --------------  
    DNG Converter  15.3 (1451)  testing   apps/DNG Converter/DNG Converter-15.3 (1451).plist  apps/DNG Converter/DNG Converter-15.3 (1451).dmg
```