### PR TITLE
Update XcodesApp.download.recipe - replacing SparkleUpdateInfoProvider with GitHubReleasesInfoProvider

### DIFF
--- a/XcodesApp/XcodesApp.download.recipe
+++ b/XcodesApp/XcodesApp.download.recipe
@@ -1,68 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of Xcodes.</string>
-	<key>Identifier</key>
-	<string>com.github.homebysix.download.XcodesApp</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Xcodes</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>2.3</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>appcast_url</key>
-				<string>https://robotsandpencils.github.io/XcodesApp/appcast.xml</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Xcodes.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.robotsandpencils.XcodesApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PBH8V487HB)</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-	</array>
-</dict>
+   <dict>
+      <key>Comment</key>
+      <string>Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)</string>
+      <key>Description</key>
+      <string>Downloads the latest version of Xcodes.</string>
+      <key>Identifier</key>
+      <string>com.github.homebysix.download.XcodesApp</string>
+      <key>Input</key>
+      <dict>
+         <key>NAME</key>
+         <string>Xcodes</string>
+      </dict>
+      <key>MinimumVersion</key>
+      <string>2.3</string>
+      <key>Process</key>
+      <array>
+         <dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+               <key>github_repo</key>
+               <string>XcodesOrg/XcodesApp</string>
+            </dict>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>filename</key>
+               <string>%NAME%-%version%.zip</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+         </dict>
+         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>archive_path</key>
+               <string>%pathname%</string>
+               <key>destination_path</key>
+               <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+               <key>purge_destination</key>
+               <true />
+            </dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+         </dict>
+         <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>input_path</key>
+               <string>%RECIPE_CACHE_DIR%/%NAME%/Xcodes.app</string>
+               <key>requirement</key>
+               <string>anchor apple generic and identifier "com.robotsandpencils.XcodesApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PBH8V487HB)</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+         </dict>
+      </array>
+   </dict>
 </plist>

--- a/XcodesApp/XcodesApp.download.recipe
+++ b/XcodesApp/XcodesApp.download.recipe
@@ -1,68 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-   <dict>
-      <key>Comment</key>
-      <string>Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)</string>
-      <key>Description</key>
-      <string>Downloads the latest version of Xcodes.</string>
-      <key>Identifier</key>
-      <string>com.github.homebysix.download.XcodesApp</string>
-      <key>Input</key>
-      <dict>
-         <key>NAME</key>
-         <string>Xcodes</string>
-      </dict>
-      <key>MinimumVersion</key>
-      <string>2.3</string>
-      <key>Process</key>
-      <array>
-         <dict>
-            <key>Processor</key>
-            <string>GitHubReleasesInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-               <key>github_repo</key>
-               <string>XcodesOrg/XcodesApp</string>
-            </dict>
-         </dict>
-         <dict>
-            <key>Arguments</key>
-            <dict>
-               <key>filename</key>
-               <string>%NAME%-%version%.zip</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-         </dict>
-         <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-         </dict>
-         <dict>
-            <key>Arguments</key>
-            <dict>
-               <key>archive_path</key>
-               <string>%pathname%</string>
-               <key>destination_path</key>
-               <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-               <key>purge_destination</key>
-               <true />
-            </dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-         </dict>
-         <dict>
-            <key>Arguments</key>
-            <dict>
-               <key>input_path</key>
-               <string>%RECIPE_CACHE_DIR%/%NAME%/Xcodes.app</string>
-               <key>requirement</key>
-               <string>anchor apple generic and identifier "com.robotsandpencils.XcodesApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PBH8V487HB)</string>
-            </dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-         </dict>
-      </array>
-   </dict>
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Xcodes.</string>
+	<key>Identifier</key>
+	<string>com.github.homebysix.download.XcodesApp</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Xcodes</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>github_repo</key>
+				<string>XcodesOrg/XcodesApp</string>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.zip</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Xcodes.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.robotsandpencils.XcodesApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PBH8V487HB)</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
I noticed that the appcast URL in the recipe wasn't working anymore, so I replaced it with the GitHubReleasesInfoProvider and specified the XcodesApp repo.