### PR TITLE
fixed regex to account for changes in URL syntax

### DIFF
--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -8,30 +8,33 @@
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.
 
 Input variable tips:
-- For major versions 10 through 15 and 18, leave the PLATFORM_ARCH blank in your override.
+- For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
 - For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
-- For major version 17, set the PLATFORM_ARCH in your override to "image".
 </string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.ParallelsDesktop</string>
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>15</string>
+		<string>18</string>
 		<key>NAME</key>
 		<string>Parallels Desktop</string>
 		<key>PLATFORM_ARCH</key>
 		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.4</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>re_flags</key>
+				<array>
+					<string>IGNORECASE</string>
+				</array>
 				<key>re_pattern</key>
-				<string>(https.*?%MAJOR_VERSION%(.*?)(?=\?|\"))</string>
+				<string>(file|DMG)\": \"(?P&lt;url_version&gt;https.*)\"[\n\s\}\,]*\"name\": \"Parallels Desktop %MAJOR_VERSION% for Mac( Image|( with (Apple )?%PLATFORM_ARCH% (chip|processor)))?\"</string>
 				<key>result_output_var_name</key>
 				<string>url_version</string>
 				<key>url</key>
@@ -44,9 +47,9 @@ Input variable tips:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%MAJOR_VERSION%%PLATFORM_ARCH%.dmg</string>
 				<key>url</key>
-				<string>%url_version%%PLATFORM_ARCH%</string>
+				<string>%url_version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Parallels/ParallelsDesktop.install.recipe
+++ b/Parallels/ParallelsDesktop.install.recipe
@@ -3,15 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Installs the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 9 through 16.
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 10 through 18.
 
-For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.
 
-For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
-
-For major version 17, set the PLATFORM_ARCH in your override to "image"
-
-This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
+Input variable tips:
+- For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
+- For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.install.recipe
+++ b/Parallels/ParallelsDesktop.install.recipe
@@ -9,7 +9,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 
 Input variable tips:
 - For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
-- For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
+- For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 10 through 18.
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION and imports it into Munki. This recipe has been tested with major versions 10 through 18.
 
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.
 

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -10,7 +10,7 @@ This recipe differs from the one in keeleysam-recipes because it offers code sig
 Input variable tips:
 - For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
 - For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
-- Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
+- Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.munki.recipe
+++ b/Parallels/ParallelsDesktop.munki.recipe
@@ -3,17 +3,14 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Parallels Desktop and imports it into Munki. This recipe has been tested with major versions 9 through 16.
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 10 through 18.
 
-For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.
 
-For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture. Create multiple overrides if you wish to offer both flavors via Munki.
-
-For major version 17, set the PLATFORM_ARCH in your override to "image"
-
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
-
-This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
+Input variable tips:
+- For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
+- For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
+- Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.ParallelsDesktop</string>
 	<key>Input</key>

--- a/Parallels/ParallelsDesktop.pkg.recipe
+++ b/Parallels/ParallelsDesktop.pkg.recipe
@@ -3,15 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Parallels Desktop and creates a package. This recipe has been tested with major versions 9 through 16.
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION and creates a package. This recipe has been tested with major versions 10 through 18.
 
-For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.
 
-For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
-
-For major version 17, set the PLATFORM_ARCH in your override to "image"
-
-This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.</string>
+Input variable tips:
+- For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
+- For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.ParallelsDesktop</string>
 	<key>Input</key>


### PR DESCRIPTION
- fixed regex to account for changes in URL syntax #596
  - now matches on download URL immediately preceding "Parallels Desktop %MAJOR_VERSION% for Mac" object name
  - added IGNORECASE to re_flags to allow %PLATFORM_ARCH% to match on object name
  - removed requirement to specify "image" as %PLATFORM_ARCH% for version 17 (not required with new method of matching on object name)
- URLDownloader now appends %MAJOR_VERSION% to file name (and %PLATFORM_ARCH% if specified)
- set default %MAJOR_VERSION% to latest tested product version
- updated MinimumVersion to 1.4 ([required for latest URLTextSearcher](https://github.com/autopkg/autopkg/wiki/Processor-URLTextSearcher#description))
- updated recipe descriptions for consistency