### PR TITLE
Updated Warp recipes to use CFBundleVersion.

### DIFF
--- a/Warp/Warp.download.recipe
+++ b/Warp/Warp.download.recipe
@@ -49,7 +49,7 @@
 				<key>input_plist_path</key>
 				<string>%pathname%/Warp.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>

--- a/Warp/Warp.munki.recipe
+++ b/Warp/Warp.munki.recipe
@@ -45,6 +45,11 @@
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--pkgvers</string>
+					<string>%version%</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
Warp's `CFBundleShortVersionString` hasn't changed in months. It appears that they're using `CFBundleVersion` to maintain the version number. This PR updates the download and Munki recipes to utilize the `CFBundleVersion`. Without the Munki update, it'll still import as `Warp-0.1.0.plist`.

- The download recipe now references CFBundleVersion.
- The Munki recipe now imports Warp with the correct version number.
