### PR TITLE
Handle new Arc version format with parentheses

### DIFF
--- a/Arc/Arc.pkg.recipe
+++ b/Arc/Arc.pkg.recipe
@@ -20,6 +20,10 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>


### PR DESCRIPTION
Before the change:

```
% autopkg run -vv 'Arc/Arc.pkg.recipe'
Processing Arc/Arc.pkg.recipe...
WARNING: Arc/Arc.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://releases.arc.net/updates.xml'}}
SparkleUpdateInfoProvider: Items in feed: 7
SparkleUpdateInfoProvider: Items in default channel: 7
SparkleUpdateInfoProvider: Version retrieved from appcast: 45028
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.25.1 (45028)
SparkleUpdateInfoProvider: Found URL https://releases.arc.net/release/Arc-1.25.1-45028.zip
{'Output': {'url': 'https://releases.arc.net/release/Arc-1.25.1-45028.zip',
            'version': '1.25.1 (45028)'}}
URLDownloader
{'Input': {'filename': 'Arc-1.25.1 (45028).zip',
           'url': 'https://releases.arc.net/release/Arc-1.25.1-45028.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 11 Jan 2024 20:23:33 GMT
URLDownloader: Storing new ETag header: "042ff7df38d141c6a582adea68b59257"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 (45028).zip
{'Output': {'download_changed': True,
            'etag': '"042ff7df38d141c6a582adea68b59257"',
            'last_modified': 'Thu, 11 Jan 2024 20:23:33 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 '
                        '(45028).zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 '
                                                                        '(45028).zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 '
                           '(45028).zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Arc-1.25.1 (45028).zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 (45028).zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app',
           'requirement': 'anchor apple generic and identifier '
                          '"company.thebrowser.Browser" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = S6N382Y83G)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app',
           'version': '1.25.1 (45028)'}}
AppPkgCreator: BundleID: company.thebrowser.Browser
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/payload/Applications/Arc.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Invalid package name
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/receipts/Arc.pkg-receipt-20240112-082207.plist

The following recipes failed:
    Arc/Arc.pkg.recipe
        Error in com.github.homebysix.pkg.Arc: Processor: AppPkgCreator: Error: Invalid package name

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 (45028).zip
```

After the change:

```
% autopkg run -vv 'Arc/Arc.pkg.recipe'
Processing Arc/Arc.pkg.recipe...
WARNING: Arc/Arc.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://releases.arc.net/updates.xml'}}
SparkleUpdateInfoProvider: Items in feed: 7
SparkleUpdateInfoProvider: Items in default channel: 7
SparkleUpdateInfoProvider: Version retrieved from appcast: 45028
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.25.1 (45028)
SparkleUpdateInfoProvider: Found URL https://releases.arc.net/release/Arc-1.25.1-45028.zip
{'Output': {'url': 'https://releases.arc.net/release/Arc-1.25.1-45028.zip',
            'version': '1.25.1 (45028)'}}
URLDownloader
{'Input': {'filename': 'Arc-1.25.1 (45028).zip',
           'url': 'https://releases.arc.net/release/Arc-1.25.1-45028.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 (45028).zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 '
                        '(45028).zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 '
                           '(45028).zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Arc-1.25.1 (45028).zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/downloads/Arc-1.25.1 (45028).zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app',
           'requirement': 'anchor apple generic and identifier '
                          '"company.thebrowser.Browser" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = S6N382Y83G)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
com.github.homebysix.VersionSplitter/VersionSplitter
{'Input': {'version': '1.25.1 (45028)'}}
VersionSplitter: Split version: 1.25.1
{'Output': {'version': '1.25.1'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app',
           'version': '1.25.1'}}
AppPkgCreator: BundleID: company.thebrowser.Browser
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc/Arc.app to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/payload/Applications/Arc.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'company.thebrowser.Browser',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc-1.25.1.pkg',
                                                        'version': '1.25.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.25.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/receipts/Arc.pkg-receipt-20240112-082342.plist

The following packages were built:
    Identifier                  Version  Pkg Path                                                                          
    ----------                  -------  --------                                                                          
    company.thebrowser.Browser  1.25.1   ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.Arc/Arc-1.25.1.pkg
```
