### PR TITLE
Adjust Ezeep recipes to use Ezeep Print App version

### DIFF
--- a/ezeep/ezeepBluePrintApp.download.recipe
+++ b/ezeep/ezeepBluePrintApp.download.recipe
@@ -52,7 +52,7 @@ For the older "ezeep Desktop" app, use the ezeepDesktop recipes.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/ezeep Print App macOS */*.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ezeep Blue Print App Mac */ezeep Print App.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>
@@ -71,6 +71,43 @@ For the older "ezeep Desktop" app, use the ezeepDesktop recipes.</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>flat_pkg_path</key>
+				<string>%found_filename%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/ezeep Print App Component.pkg/Payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Applications/ezeep Print App/ezeep Print App.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
 		</dict>
 	</array>
 </dict>

--- a/ezeep/ezeepBluePrintApp.munki.recipe
+++ b/ezeep/ezeepBluePrintApp.munki.recipe
@@ -17,6 +17,13 @@ For the older "ezeep Desktop" app, use the ezeepDesktop recipes.</string>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>ezeep Print App</string>
+		<key>pkg_ids_set_optional_true</key>
+		<array>
+			<string>com.thinprint.ezeep.printapp.logging</string>
+			<string>com.thinprint.ezeep.printapp.printerdriver</string>
+			<string>com.ThinPrint.TPAutoConnect.PPDGen</string>
+			<string>com.ThinPrint.TPAutoConnect</string>
+		</array>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>
@@ -49,6 +56,18 @@ For the older "ezeep Desktop" app, use the ezeepDesktop recipes.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%found_filename%</string>
 				<key>repo_subdirectory</key>
@@ -56,6 +75,15 @@ For the older "ezeep Desktop" app, use the ezeepDesktop recipes.</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkginfo_repo_path</key>
+				<string>%pkginfo_repo_path%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiOptionalReceiptEditor</string>
 		</dict>
 	</array>
 </dict>

--- a/ezeep/ezeepBluePrintApp.pkg.recipe
+++ b/ezeep/ezeepBluePrintApp.pkg.recipe
@@ -26,7 +26,7 @@ For the older "ezeep Desktop" app, use the ezeepDesktop recipes.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
 				<string>%found_filename%</string>
 			</dict>


### PR DESCRIPTION
This PR adjusts the Ezeep recipes to reflect new zip file contents, uses the enclosed app for versioning, and marks many package receipts as optional to support that versioning scheme.

Note: Munki administrators may need to retroactively adjust the versioning on previous pkginfos in order to properly offer the upgrade from an old version (which might have been numbered as 12.x) to a new version (numbered as 1.0.x).