### PR TITLE
Update AutodeskFusion360 download

### DIFF
--- a/AutodeskFusion360/AutodeskFusion360.download.recipe
+++ b/AutodeskFusion360/AutodeskFusion360.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Autodesk Fusion 360.</string>
+	<string>Downloads the latest version of Autodesk Fusion.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.AutodeskFusion360</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>Autodesk Fusion 360</string>
+		<string>Autodesk Fusion</string>
 		<key>USER_AGENT</key>
 		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30</string>
 	</dict>
@@ -21,14 +21,14 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.pkg</string>
+				<string>%NAME%.dmg</string>
 				<key>request_headers</key>
 				<dict>
 					<key>user-agent</key>
 					<string>%USER_AGENT%</string>
 				</dict>
 				<key>url</key>
-				<string>https://dl.appstreaming.autodesk.com/production/installers/Autodesk%20Fusion%20360%20Admin%20Install.pkg</string>
+				<string>https://dl.appstreaming.autodesk.com/production/installers/Fusion%20Client%20Downloader.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -40,14 +40,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: Autodesk (XXKJ396S2Y)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
+				<key>Requirement</key>
+				<string>anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XXKJ396S2Y</string>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Install Autodesk Fusion.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Autodesk switched to a DMG download, modified their code signature from expected authority name to requirement, and dropped "360" from the Fusion 360 app name