### PR TITLE
Remove unneeded MunkiPkginfoMerger process

### DIFF
--- a/Grammarly/Grammarly.munki.recipe
+++ b/Grammarly/Grammarly.munki.recipe
@@ -39,10 +39,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>


### PR DESCRIPTION
This caused the following error output:

```
The following recipes failed:
    grammarly.munki
        MunkiPkginfoMerger requires missing argument additional_pkginfo
```