### PR TITLE
Update Bartender.download.recipe

### DIFF
--- a/Bartender/Bartender.download.recipe
+++ b/Bartender/Bartender.download.recipe
@@ -75,7 +75,7 @@ Specify which major version you want in the MAJOR_VERSION input variable. Suppor
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Bartender %MAJOR_VERSION%.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.surteesstudios.Bartender" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8DD663WDX4")</string>
+				<string>anchor apple generic and identifier "com.surteesstudios.Bartender" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "24J875RH8J")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
New certificate ID for Bartender as of the new version of Bartender 5 released on May 16, 2024.