### PR TITLE
Update DockerDesktop.download.recipe

### DIFF
--- a/Docker/DockerDesktop.download.recipe
+++ b/Docker/DockerDesktop.download.recipe
@@ -28,11 +28,24 @@ required to support Apple Silicon Macs.</string>
 	<array>
 		<dict>
 			<key>Arguments</key>
+				<dict>
+				<key>re_pattern</key>
+				<string>https://desktop\.docker\.com/mac/main/%PLATFORM_ARCH%/[A-Za-z0-9]+/Docker\.dmg</string>
+				<key>result_output_var_name</key>
+				<string>DOWNLOAD_URL</string>
+				<key>url</key>
+				<string>https://docs.docker.com/desktop/release-notes/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
 				<string>%NAME%-%PLATFORM_ARCH%.dmg</string>
 				<key>url</key>
-				<string>https://desktop.docker.com/mac/main/%PLATFORM_ARCH%/Docker.dmg</string>
+				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @homebysix 

The current Docker download recipe uses the static URL featured on the vendors main download page, this is currently pulling down an older version of the Application `v4.31.0`

The PR adds in `URLTextSearcher` to get the latest download URL from the [release notes page](https://docs.docker.com/desktop/release-notes/) which seems to get the latest releases first. With this change the recipe grabs `v4.32.0`

 Outputs from successful `amd64` and `arm64` runs
```
Docker % autopkg run -v DockerDesktop.munki.recipe
Looking for com.github.homebysix.download.DockerDesktop...
Did not find com.github.homebysix.download.DockerDesktop in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.DockerDesktop...
Found com.github.homebysix.download.DockerDesktop in recipe map
**load_recipe time: 0.006599790998734534
Processing DockerDesktop.munki.recipe...
WARNING: DockerDesktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://desktop.docker.com/mac/main/amd64/157355/Docker.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 04 Jul 2024 09:48:26 GMT
URLDownloader: Storing new ETag header: "35b7e6201b7daef3f1c8df9463b144b8"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.0mZiGT/Docker.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.0mZiGT/Docker.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.0mZiGT/Docker.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg
Versioner: Found version 4.32.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg/Docker.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Docker/Docker-4.32.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Docker/Docker-amd64-4.32.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/receipts/DockerDesktop.munki-receipt-20240708-104933.plist

The following new items were downloaded:
    Download Path                                                                                                 
    -------------                                                                                                 
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                     Pkg Repo Path                        Icon Repo Path  
    ----    -------  --------  ------------                     -------------                        --------------  
    Docker  4.32.0   testing   apps/Docker/Docker-4.32.0.plist  apps/Docker/Docker-amd64-4.32.0.dmg
```
```
autopkg run -v DockerDesktop.munki.recipe
Looking for com.github.homebysix.download.DockerDesktop...
Did not find com.github.homebysix.download.DockerDesktop in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.DockerDesktop...
Found com.github.homebysix.download.DockerDesktop in recipe map
**load_recipe time: 0.007205415982753038
Processing DockerDesktop.munki.recipe...
WARNING: DockerDesktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://desktop.docker.com/mac/main/arm64/157355/Docker.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 04 Jul 2024 09:48:13 GMT
URLDownloader: Storing new ETag header: "751cbb1a5715b2f0e5537fe2840048bf"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-arm64.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Vz2Mgs/Docker.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Vz2Mgs/Docker.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Vz2Mgs/Docker.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-arm64.dmg
Versioner: Found version 4.32.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-arm64.dmg/Docker.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Docker/Docker-4.32.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Docker/Docker-arm64-4.32.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/receipts/DockerDesktop.munki-receipt-20240708-105103.plist

The following new items were downloaded:
    Download Path                                                                                                 
    -------------                                                                                                 
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-arm64.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                        Pkg Repo Path                        Icon Repo Path  
    ----    -------  --------  ------------                        -------------                        --------------  
    Docker  4.32.0   testing   apps/Docker/Docker-4.32.0__1.plist  apps/Docker/Docker-arm64-4.32.0.dmg
```