### PR TITLE
Update Grammarly.download.recipe

### DIFF
--- a/Grammarly/Grammarly.download.recipe
+++ b/Grammarly/Grammarly.download.recipe
@@ -49,7 +49,7 @@
 				<key>input_plist_path</key>
 				<string>%pathname%/Grammarly Installer.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>


### PR DESCRIPTION
Is there a reason the recipe specifies CFBundleVersion rather than the default CFBundleShortVersionString?  Jamf's Patch Management definition uses the shorter version so this throws out patching if Jamf Pro is used ... can it use the shorter string instead?