### PR TITLE
Duet display

### DIFF
--- a/DuetDisplay/duet.download.recipe
+++ b/DuetDisplay/duet.download.recipe
@@ -5,19 +5,13 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of duet.
-
-To download the latest version of duet (macOS 12.3 and above) set DOWNLOAD_VERSION to "AppleSilicon" - Please note the "AppleSilicon" version is Universal.
-
-To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_VERSION to "legacyMac"</string>
+	<string>Downloads the latest version of duet.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.duet</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>duet</string>
-		<key>DOWNLOAD_VERSION</key>
-		<string>AppleSilicon</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -29,7 +23,7 @@ To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_V
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://updates.duetdisplay.com/%DOWNLOAD_VERSION%</string>
+				<string>https://updates.duetdisplay.com/AppleSilicon</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/DuetDisplay/duet.download.recipe
+++ b/DuetDisplay/duet.download.recipe
@@ -27,7 +27,7 @@ To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_V
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
+				<string>%NAME%.dmg</string>
 				<key>url</key>
 				<string>https://updates.duetdisplay.com/%DOWNLOAD_VERSION%</string>
 			</dict>
@@ -41,21 +41,8 @@ To download the latest legacy version of duet (macOS 10.9 - 12.2) set DOWNLOAD_V
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/duet.app</string>
+				<string>%pathname%/duet.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.kairos.duetMac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = J6L96W8A86)</string>
 			</dict>

--- a/DuetDisplay/duet.install.recipe
+++ b/DuetDisplay/duet.install.recipe
@@ -23,18 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/DuetDisplay/duet.munki.recipe
+++ b/DuetDisplay/duet.munki.recipe
@@ -45,19 +45,8 @@ If downloading the latest legacy version of duet (macOS 10.9 - 12.2) set maximum
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/DuetDisplay/duet.munki.recipe
+++ b/DuetDisplay/duet.munki.recipe
@@ -5,9 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of duet and imports it into Munki.
-
-If downloading the latest legacy version of duet (macOS 10.9 - 12.2) set maximum_os_version to 12.2 otherwise please leave blank.</string>
+	<string>Downloads the latest version of duet and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.duet</string>
 	<key>Input</key>

--- a/DuetDisplay/duet.pkg.recipe
+++ b/DuetDisplay/duet.pkg.recipe
@@ -24,6 +24,31 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/duet.app</string>
+				<key>source_path</key>
+				<string>%pathname%/duet.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/duet.app</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleShortVersionString</key>
+					<string>version</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_request</key>
 				<dict>
 					<key>chown</key>
@@ -51,6 +76,17 @@
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @homebysix 

Duet have changed the downloaded file format from .zip to .dmg on the latest version DuetDesktop for [macOS 11+](https://updates.duetdisplay.com/AppleSilicon)

Unfortunately the legacy application for [10.13 - 10.15](https://updates.duetdisplay.com/IntelMac) hasn't yet (and possibly may never be?) been updated to the new format and is still a .zip file.

As per issue: https://github.com/autopkg/homebysix-recipes/issues/661 this PR updates to account for the switch from .zip to dmg and removes support for the legacy application.

Output from successful -v runs of the pkg, munki and install recipes
```
autopkg run -v duet.pkg.recipe
Looking for com.github.homebysix.download.duet...
Did not find com.github.homebysix.download.duet in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.duet...
Found com.github.homebysix.download.duet in recipe map
**load_recipe time: 0.0070136249996721745
Processing duet.pkg.recipe...
WARNING: duet.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 30 Oct 2024 19:48:56 GMT
URLDownloader: Storing new ETag header: "8a10fcd2576e68c12a22ae78bc3b1946-1"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/downloads/duet.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/downloads/duet.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.gTab5F/duet.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.gTab5F/duet.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.gTab5F/duet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Copier
Copier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/downloads/duet.dmg
Copier: Copied /private/tmp/dmg.O1X52h/duet.app to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/duet/Applications/duet.app
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/duet/Applications/duet.app/Contents/Info.plist
PlistReader: Assigning value of '3.20.0.0' to output variable 'version'
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/duet
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/receipts/duet.pkg-receipt-20241104-193342.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/downloads/duet.dmg  

The following packages were built:
    Identifier       Version   Pkg Path                                                                                  
    ----------       -------   --------                                                                                  
    com.kairos.duet  3.20.0.0  /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.pkg.duet/duet-3.20.0.0.pkg  



autopkg run -v duet.munki.recipe 
Looking for com.github.homebysix.download.duet...
Did not find com.github.homebysix.download.duet in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.duet...
Found com.github.homebysix.download.duet in recipe map
**load_recipe time: 0.00705158400523942
Processing duet.munki.recipe...
WARNING: duet.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 30 Oct 2024 19:48:56 GMT
URLDownloader: Storing new ETag header: "8a10fcd2576e68c12a22ae78bc3b1946-1"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uCeKVg/duet.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uCeKVg/duet.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uCeKVg/duet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/duet/duet-3.20.0.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/duet/duet-3.20.0.0__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/receipts/duet.munki-receipt-20241104-193508.plist

The following new items were downloaded:
    Download Path                                                                                
    -------------                                                                                
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.duet/downloads/duet.dmg  

The following new items were imported into Munki:
    Name  Version   Catalogs  Pkginfo Path                      Pkg Repo Path                   Icon Repo Path  
    ----  -------   --------  ------------                      -------------                   --------------  
    duet  3.20.0.0  testing   apps/duet/duet-3.20.0.0__1.plist  apps/duet/duet-3.20.0.0__1.dmg                  



autopkg run -v duet.install.recipe 
Looking for com.github.homebysix.download.duet...
Did not find com.github.homebysix.download.duet in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.duet...
Found com.github.homebysix.download.duet in recipe map
**load_recipe time: 0.005769166004029103
Processing duet.install.recipe...
WARNING: duet.install.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 30 Oct 2024 19:48:56 GMT
URLDownloader: Storing new ETag header: "8a10fcd2576e68c12a22ae78bc3b1946-1"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.install.duet/downloads/duet.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.install.duet/downloads/duet.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.QP6qmv/duet.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.QP6qmv/duet.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.QP6qmv/duet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
InstallFromDMG
InstallFromDMG: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.install.duet/downloads/duet.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying duet.app to /Applications/duet.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.install.duet/receipts/duet.install-receipt-20241104-193534.plist

The following new items were downloaded:
    Download Path                                                                                  
    -------------                                                                                  
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.install.duet/downloads/duet.dmg  

Items from the following disk images were successfully installed:
    Dmg Path                                                                                       
    --------                                                                                       
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.install.duet/downloads/duet.dmg
``` 

