### PR TITLE
Update Acorn and Bartender signatures

### DIFF
--- a/Bartender/Bartender.download.recipe
+++ b/Bartender/Bartender.download.recipe
@@ -75,7 +75,7 @@ Specify which major version you want in the MAJOR_VERSION input variable. Suppor
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Bartender %MAJOR_VERSION%.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.surteesstudios.Bartender" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8DD663WDX4")</string>
+				<string>anchor apple generic and identifier "com.surteesstudios.Bartender" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "24J875RH8J")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/FlyingMeat/Acorn.download.recipe
+++ b/FlyingMeat/Acorn.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Acorn.app</string>
 				<key>requirement</key>
-				<string>identifier "com.flyingmeat.Acorn7" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WZCN9HJ4VP</string>
+				<string>identifier "com.flyingmeat.Acorn8" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WZCN9HJ4VP</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
- Acorn is now version 8, so it has a new signature.
- https://github.com/autopkg/homebysix-recipes/pull/668 changed Bartender's signature, but I'm now seeing errors that indicate the original signature was correct.