### PR TITLE
Enhance JamfSetupManager.download

### DIFF
--- a/JamfSetupManager/JamfSetupManager.download.recipe
+++ b/JamfSetupManager/JamfSetupManager.download.recipe
@@ -5,13 +5,16 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Setup Manager.</string>
+	<string>Downloads the latest version of Jamf Setup Manager.
+If you wish to download a pre-release version if it is the most recent, set INCL_PRERELEASES to any non-empty value.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.JamfSetupManager</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>JamfSetupManager</string>
+		<key>INCL_PRERELEASES</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.3</string>
@@ -22,16 +25,13 @@
 			<dict>
 				<key>github_repo</key>
 				<string>Jamf-Concepts/Setup-Manager</string>
+				<key>include_prereleases</key>
+				<string>%INCL_PRERELEASES%</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.pkg</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>


### PR DESCRIPTION
This adds support for downloading (or choosing not to download) the pre-release version if it is the most recent release. As well, since the pkg being downloaded generates a reasonable filename for most uses, renaming the pkg is removed from the download recipe. If the user wants the %NAME%-%version%.pkg name, they can run the pkg recipe, since it renames the pkg to that. If they prefer the version number with build number that automatically comes with the GitHub-provided pkg, they can use this version of the download recipe as a parent.

Test run of download recipe (unfortunately, the current version is a full release, so the pre-release functionality cannot be tested):
```
% autopkg run -vv --ignore-parent-trust-verification-errors JamfSetupManager.download                               
Processing JamfSetupManager.download...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'Jamf-Concepts/Setup-Manager',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'Setup.Manager.1.1-496.pkg' from release 'v1.1'
{'Output': {'asset_created_at': '2024-10-29T14:06:46Z',
            'asset_url': 'https://api.github.com/repos/Jamf-Concepts/Setup-Manager/releases/assets/202596768',
            'release_notes': '### New Features\r\n'
                             '\r\n'
                             '- new action '
                             '[`waitForUserEntry`](ConfigurationProfile.md#wait-for-user-entry) '
                             'which allows for two-phase installation '
                             'workflows in Jamf Pro. When Setup Manager '
                             'reaches this action it will wait for the user '
                             'entry to save the data entry, then it will run a '
                             'recon/Update Inventory. Policy actions that '
                             'follow this, can then be scoped to data from the '
                             'user entry. (Jamf-Concepts/Setup-Manager#11)\r\n'
                             '- data from user entry is now written to a file '
                             'when Setup Manager submits data. See details in '
                             '[User Entry](Docs/Extras.md#user-data-file) '
                             '(Jamf-Concepts/Setup-Manager#9)\r\n'
                             '- use token substitution in the `title`, '
                             '`message`, and action `label` values (as well as '
                             '`computerNameTemplate`)\r\n'
                             '- token substitution can extract center '
                             'characters with `:=n`\r\n'
                             '- localization of custom text in the '
                             'configuration profile has been simplified. The '
                             'previous method still works, but is considered '
                             'deprecated. [Details in the '
                             'documentation](ConfigurationProfile.md#localization). '
                             'The [plist and profile example files](Examples) '
                             'have been updated.\r\n'
                             '\r\n'
                             '### Fixes and improvements\r\n'
                             '\r\n'
                             '1.1beta:\r\n'
                             '\r\n'
                             '- icons using `symbol:` that end in `.app` now '
                             'work properly\r\n'
                             '- Elapsed time is shown in "About this Mac…" '
                             'Start time is shown with option key.\r\n'
                             '- svg and pdf images used for `icon`s should now '
                             'work\r\n'
                             '- general fixes in user entry setup\r\n'
                             '- improved rendering in Help View '
                             '(Jamf-Concepts/Setup-Manager#12)\r\n'
                             '- fixes to json schema\r\n'
                             '- improved and updated documentation\r\n'
                             '- included Installomator script updated to '
                             '[v10.6](https://github.com/Installomator/Installomator/releases/v10.6)\r\n'
                             '- added Setup Manager version and macOS version '
                             'and build to tracking ping\r\n'
                             '- fixed UI glitch in macOS Sequoia\r\n'
                             '\r\n'
                             '1.1 release:\r\n'
                             '\r\n'
                             '- documentation updates and fixes '
                             '(Jamf-Concepts/Setup-Manager#35, '
                             'Jamf-Concepts/Setup-Manager#44, '
                             'Jamf-Concepts/Setup-Manager#48, '
                             'Jamf-Concepts/Setup-Manager#51)\r\n'
                             '- custom `accentColor` now works correctly with '
                             'SF Symbol icons '
                             '(Jamf-Concepts/Setup-Manager#41)\r\n'
                             '- setting a `placeholder` no longer overrides a '
                             '`default` in `userEntry` '
                             '(Jamf-Concepts/Setup-Manager#43)\r\n'
                             '- more UI updates\r\n'
                             '- Hebrew localization\r\n'
                             '\r\n'
                             '### Beta features\r\n'
                             '\r\n'
                             'Even though we are confident that the 1.1 '
                             'release is overall stable and ready to be used '
                             'in production, we believe this feature may '
                             'require more testing. When, after thorough '
                             'testing in your environment, you conclude this '
                             'works for your workflow, please let us know '
                             'about success or any issues you might '
                             'encounter.\r\n'
                             '\r\n'
                             '- Setup Manager can now run over Login Window, '
                             'instead of immediately after installation. This '
                             'also allows Setup Manager to work with '
                             'AutoAdvance. Use [the new `runAt` '
                             'key](ConfigurationProfile.md#runAt) in the '
                             'profile to determine when Setup Manager runs '
                             '(Jamf-Concepts/Setup-Manager#18)\r\n'
                             '\r\n'
                             '### Deprecations\r\n'
                             '\r\n'
                             'These features are marked for removal in a '
                             'future release:\r\n'
                             '\r\n'
                             '- localized labels and text by adding the '
                             'two-letter language code to key. Switch to '
                             '[localization with '
                             'dictionaries](ConfigurationProfile.md#localization). \r\n'
                             '- `showBothButtons` key and functionality\r\n',
            'url': 'https://github.com/Jamf-Concepts/Setup-Manager/releases/download/v1.1/Setup.Manager.1.1-496.pkg',
            'version': '1.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/Jamf-Concepts/Setup-Manager/releases/download/v1.1/Setup.Manager.1.1-496.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 29 Oct 2024 14:06:47 GMT
URLDownloader: Storing new ETag header: "0x8DCF822EDA46302"
URLDownloader: Downloaded /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.download.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DCF822EDA46302"',
            'last_modified': 'Tue, 29 Oct 2024 14:06:47 GMT',
            'pathname': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.download.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.download.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: JAMF Software '
                                        '(483DWKW443)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.download.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Setup.Manager.1.1-496.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-29 10:51:56 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: JAMF Software (483DWKW443)
CodeSignatureVerifier:        Expires: 2027-06-01 16:58:54 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CB 3C 51 9C E7 9B 47 8D 81 4A C7 FA 17 46 36 1F 9F 3C F9 5A 7B 48 
CodeSignatureVerifier:            92 E7 DF 0B 58 DD E1 EE 1B DD
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.download.JamfSetupManager/receipts/JamfSetupManager-receipt-20250121-145119.plist

The following new items were downloaded:
    Download Path                                                                                                             
    -------------                                                                                                             
    /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.download.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg

```

Run of the pkg recipe with this version as the parent (pkg is successfully renamed to %NAME%-%version%.pkg):
```
% autopkg run -vv --ignore-parent-trust-verification-errors JamfSetupManager.pkg  
Processing JamfSetupManager.pkg...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'Jamf-Concepts/Setup-Manager',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'Setup.Manager.1.1-496.pkg' from release 'v1.1'
{'Output': {'asset_created_at': '2024-10-29T14:06:46Z',
            'asset_url': 'https://api.github.com/repos/Jamf-Concepts/Setup-Manager/releases/assets/202596768',
            'release_notes': '### New Features\r\n'
                             '\r\n'
                             '- new action '
                             '[`waitForUserEntry`](ConfigurationProfile.md#wait-for-user-entry) '
                             'which allows for two-phase installation '
                             'workflows in Jamf Pro. When Setup Manager '
                             'reaches this action it will wait for the user '
                             'entry to save the data entry, then it will run a '
                             'recon/Update Inventory. Policy actions that '
                             'follow this, can then be scoped to data from the '
                             'user entry. (Jamf-Concepts/Setup-Manager#11)\r\n'
                             '- data from user entry is now written to a file '
                             'when Setup Manager submits data. See details in '
                             '[User Entry](Docs/Extras.md#user-data-file) '
                             '(Jamf-Concepts/Setup-Manager#9)\r\n'
                             '- use token substitution in the `title`, '
                             '`message`, and action `label` values (as well as '
                             '`computerNameTemplate`)\r\n'
                             '- token substitution can extract center '
                             'characters with `:=n`\r\n'
                             '- localization of custom text in the '
                             'configuration profile has been simplified. The '
                             'previous method still works, but is considered '
                             'deprecated. [Details in the '
                             'documentation](ConfigurationProfile.md#localization). '
                             'The [plist and profile example files](Examples) '
                             'have been updated.\r\n'
                             '\r\n'
                             '### Fixes and improvements\r\n'
                             '\r\n'
                             '1.1beta:\r\n'
                             '\r\n'
                             '- icons using `symbol:` that end in `.app` now '
                             'work properly\r\n'
                             '- Elapsed time is shown in "About this Mac…" '
                             'Start time is shown with option key.\r\n'
                             '- svg and pdf images used for `icon`s should now '
                             'work\r\n'
                             '- general fixes in user entry setup\r\n'
                             '- improved rendering in Help View '
                             '(Jamf-Concepts/Setup-Manager#12)\r\n'
                             '- fixes to json schema\r\n'
                             '- improved and updated documentation\r\n'
                             '- included Installomator script updated to '
                             '[v10.6](https://github.com/Installomator/Installomator/releases/v10.6)\r\n'
                             '- added Setup Manager version and macOS version '
                             'and build to tracking ping\r\n'
                             '- fixed UI glitch in macOS Sequoia\r\n'
                             '\r\n'
                             '1.1 release:\r\n'
                             '\r\n'
                             '- documentation updates and fixes '
                             '(Jamf-Concepts/Setup-Manager#35, '
                             'Jamf-Concepts/Setup-Manager#44, '
                             'Jamf-Concepts/Setup-Manager#48, '
                             'Jamf-Concepts/Setup-Manager#51)\r\n'
                             '- custom `accentColor` now works correctly with '
                             'SF Symbol icons '
                             '(Jamf-Concepts/Setup-Manager#41)\r\n'
                             '- setting a `placeholder` no longer overrides a '
                             '`default` in `userEntry` '
                             '(Jamf-Concepts/Setup-Manager#43)\r\n'
                             '- more UI updates\r\n'
                             '- Hebrew localization\r\n'
                             '\r\n'
                             '### Beta features\r\n'
                             '\r\n'
                             'Even though we are confident that the 1.1 '
                             'release is overall stable and ready to be used '
                             'in production, we believe this feature may '
                             'require more testing. When, after thorough '
                             'testing in your environment, you conclude this '
                             'works for your workflow, please let us know '
                             'about success or any issues you might '
                             'encounter.\r\n'
                             '\r\n'
                             '- Setup Manager can now run over Login Window, '
                             'instead of immediately after installation. This '
                             'also allows Setup Manager to work with '
                             'AutoAdvance. Use [the new `runAt` '
                             'key](ConfigurationProfile.md#runAt) in the '
                             'profile to determine when Setup Manager runs '
                             '(Jamf-Concepts/Setup-Manager#18)\r\n'
                             '\r\n'
                             '### Deprecations\r\n'
                             '\r\n'
                             'These features are marked for removal in a '
                             'future release:\r\n'
                             '\r\n'
                             '- localized labels and text by adding the '
                             'two-letter language code to key. Switch to '
                             '[localization with '
                             'dictionaries](ConfigurationProfile.md#localization). \r\n'
                             '- `showBothButtons` key and functionality\r\n',
            'url': 'https://github.com/Jamf-Concepts/Setup-Manager/releases/download/v1.1/Setup.Manager.1.1-496.pkg',
            'version': '1.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/Jamf-Concepts/Setup-Manager/releases/download/v1.1/Setup.Manager.1.1-496.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 29 Oct 2024 14:06:47 GMT
URLDownloader: Storing new ETag header: "0x8DCF822EDA46302"
URLDownloader: Downloaded /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DCF822EDA46302"',
            'last_modified': 'Tue, 29 Oct 2024 14:06:47 GMT',
            'pathname': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: JAMF Software '
                                        '(483DWKW443)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Setup.Manager.1.1-496.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-29 10:51:56 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: JAMF Software (483DWKW443)
CodeSignatureVerifier:        Expires: 2027-06-01 16:58:54 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CB 3C 51 9C E7 9B 47 8D 81 4A C7 FA 17 46 36 1F 9F 3C F9 5A 7B 48 
CodeSignatureVerifier:            92 E7 DF 0B 58 DD E1 EE 1B DD
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/JamfSetupManager-1.1.pkg',
           'source_pkg': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg'}}
PkgCopier: Copied /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg to /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/JamfSetupManager-1.1.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/JamfSetupManager-1.1.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/JamfSetupManager-1.1.pkg'}}
Receipt written to /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/receipts/JamfSetupManager-receipt-20250121-150530.plist

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/downloads/Setup.Manager.1.1-496.pkg  

The following packages were copied:
    Pkg Path                                                                                                  
    --------                                                                                                  
    /Volumes/AutoPkgLibrary/AutoPkg/Cache/com.github.homebysix.pkg.JamfSetupManager/JamfSetupManager-1.1.pkg
```