### PR TITLE
Updated MySQL Workbench URLs

### DIFF
--- a/MySQLWorkbench/MySQLWorkbench.download.recipe
+++ b/MySQLWorkbench/MySQLWorkbench.download.recipe
@@ -33,7 +33,7 @@ Set the ARCH input variable based on the desired architecture:
 					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36</string>
 				</dict>
 				<key>url</key>
-				<string>https://dev.mysql.com/downloads/workbench</string>
+				<string>https://dev.mysql.com/downloads/workbench/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -44,7 +44,7 @@ Set the ARCH input variable based on the desired architecture:
 				<key>filename</key>
 				<string>%NAME%-%ARCH%-%version%.dmg</string>
 				<key>url</key>
-				<string>https://dev.mysql.com/get/Downloads/MySQLGUITools/%dmg%</string>
+				<string>https://cdn.mysql.com/Downloads/MySQLGUITools/%dmg%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
I started getting the following download error using the MySQL Workbench recipe:
> The following recipes failed:
    com.github.homebysix.download.MySQLWorkbench
        Error in com.github.homebysix.download.MySQLWorkbench: Processor: URLDownloader: Error: curl: (56) The requested URL returned error: 403

This PR resolves the issue by updating the version check and download URL.

Version check URL — I'm not entirely sure why, but when using `arm64` the URL worked fine, but `x86_64` it was getting redirected to append a `/` to the URL. So, I simply added a trailing `/` and now the version check recipe is working for me using either architecture.

The download URL now seems to redirect to a CDN host. I've updated the URL with the CDN host.

Here's output from both architecture runs:

```
 ▶ autopkg run -d $(pwd) com.github.homebysix.download.MySQLWorkbench
Processing com.github.homebysix.download.MySQLWorkbench...
WARNING: com.github.homebysix.download.MySQLWorkbench is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.homebysix.download.MySQLWorkbench/downloads/MySQLWorkbench-x86_64-8.0.41.dmg
```

---

```
 ▶ autopkg run -d $(pwd) com.github.homebysix.download.MySQLWorkbench
Processing com.github.homebysix.download.MySQLWorkbench...
WARNING: com.github.homebysix.download.MySQLWorkbench is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.homebysix.download.MySQLWorkbench/downloads/MySQLWorkbench-arm64-8.0.41.dmg
```