### PR TITLE
Update Inkscape.pkg.recipe to rename using NAME

### DIFF
--- a/Inkscape/Inkscape.pkg.recipe
+++ b/Inkscape/Inkscape.pkg.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Inkscape and builds a package.</string>
+	<string>Downloads the latest version of Inkscape and builds a package.
+If you need to deploy both Intel and Apple Silicon versions of this app, use the NAME input variable
+in your override to add architecture information to your package name (e.g., Inkscape-Intel).</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.Inkscape</string>
 	<key>Input</key>
@@ -31,6 +33,11 @@
 			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>


### PR DESCRIPTION
Change the AppPkgCreator processor to name the pkg NAME-version.pkg (currently app_name-version.pkg). This is to support management systems (such as Jamf Pro) that only distinguish pkgs by name. Since this app has Intel and Apple Silicon versions, a recipe user might want an override for both and a different name for both. Using NAME to distinguish between the two is arguably the simplest change. Documentation has been added to the description to provide guidance. Further discussion is in the Mac Admins Slack on 2025-02-14 (https://macadmins.slack.com/archives/C056155B4/p1739544063879779).