### PR TITLE
Cleanup temp app bundle and DMG for xScope recipes

### DIFF
--- a/Iconfactory/xScope.install.recipe
+++ b/Iconfactory/xScope.install.recipe
@@ -48,6 +48,18 @@
 			<key>Processor</key>
 			<string>InstallFromDMG</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Iconfactory/xScope.munki.recipe
+++ b/Iconfactory/xScope.munki.recipe
@@ -60,6 +60,18 @@
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Iconfactory/xScope.pkg.recipe
+++ b/Iconfactory/xScope.pkg.recipe
@@ -52,6 +52,17 @@
 			<key>Processor</key>
 			<string>PkgCreator</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi there 👋

The **xScope** recipes leave residual app bundles + DMGs around, so this PR attempts to cleanup files that are no longer required.

Should save approximately **40MB** of disk space per recipe!