### PR TITLE
removed PkgCreator processor run with bundled postinstall

### DIFF
--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -22,20 +22,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/expanded</string>
 				<key>flat_pkg_path</key>
@@ -48,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+				<string>%RECIPE_CACHE_DIR%/expanded</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/expanded/zoomus.pkg/Payload</string>
 			</dict>
@@ -59,13 +45,13 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/zoom.us.app/Contents/Info.plist</string>
+				<string>%destination_path%/zoom.us.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
-					<key>CFBundleVersion</key>
-					<string>version</string>
 					<key>CFBundleShortVersionString</key>
 					<string>jamfversion</string>
+					<key>CFBundleVersion</key>
+					<string>version</string>
 					<key>LSMinimumSystemVersion</key>
 					<string>min_os_version</string>
 				</dict>
@@ -76,33 +62,13 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>scripts</key>
-					<string>scripts</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>PkgCopier</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>


### PR DESCRIPTION
- removed PkgCreator processor run with bundled postinstall (closes #594)
- grouped tmp resources in `%RECIPE_CACHE_DIR%/expanded` for consolidated cleanup in PathDeleter run
- added PkgCopier processor run to update `%pkg_path%` (replaces behavior from PkgCreator)