### PR TITLE
Update coconutBattery appcast URL

### DIFF
--- a/coconutBattery/coconutBattery.download.recipe
+++ b/coconutBattery/coconutBattery.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>
-				<string>https://coconut-flavour.com/updates/coconutBattery.xml</string>
+				<string>https://coconut-flavour.com/updates/coconutBattery_4.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
URL has changed. The new URL is also in the app (info.plist).