### PR TITLE
Fix for Tracker Munki recipe

### DIFF
--- a/Tracker/Tracker.munki.recipe
+++ b/Tracker/Tracker.munki.recipe
@@ -49,7 +49,7 @@
 					<array>
 						<dict>
 							<key>path</key>
-							<string>/Applications/Tracker.app/Contents/Java/tracker-%version%.jar</string>
+							<string>/Applications/Tracker.app/Contents/app/tracker-%version%.jar</string>
 							<key>type</key>
 							<string>file</string>
 						</dict>


### PR DESCRIPTION
The path to the JAR file used to the installs array has changed.  It is now in `Applications/Tracker.app/Contents/app` rather than `/Applications/Tracker.app/Contents/Java`    This pull request fixes that path in `additional_pkginfo` 