### PR TITLE
Architecture Support for WordPress.com

### DIFF
--- a/Automattic/WordPress.com.download.recipe
+++ b/Automattic/WordPress.com.download.recipe
@@ -5,11 +5,16 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of WordPress.com.</string>
+	<string>Downloads the latest version of WordPress.com.
+
+To download Apple Silicon use: "-silicon" in the DOWNLOAD_ARCH variable
+To download Intel leave the DOWNLOAD_ARCH variable empty</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.WordPress.com</string>
 	<key>Input</key>
 	<dict>
+		<key>DOWNLOAD_ARCH</key>
+		<string>-silicon</string>
 		<key>NAME</key>
 		<string>WordPress.com</string>
 	</dict>
@@ -21,11 +26,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(rest/v[\d\.]+/desktop/osx/download\?type=dmg)</string>
+				<string>(rest/v[\d\.]+/desktop/osx%DOWNLOAD_ARCH%/download\?type=dmg)</string>
 				<key>result_output_var_name</key>
 				<string>download_path</string>
 				<key>url</key>
-				<string>https://apps.wordpress.com/d/osx/</string>
+				<string>https://apps.wordpress.com/d/osx%DOWNLOAD_ARCH%/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Automattic/WordPress.com.munki.recipe
+++ b/Automattic/WordPress.com.munki.recipe
@@ -5,7 +5,10 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of WordPress.com and imports it into Munki.</string>
+	<string>Downloads the latest version of WordPress.com and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.WordPress.com</string>
 	<key>Input</key>
@@ -14,6 +17,8 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>WordPress.com</string>
+		<key>SUPPORTED_ARCH</key>
+		<string>arm64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -28,6 +33,10 @@
 			<string>WordPress.com</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Hi, @homebysix 

This PR adds architecture support for WordPress.com

Output from successful -v runs
```
Looking for com.github.homebysix.download.WordPress.com...
Did not find com.github.homebysix.download.WordPress.com in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.WordPress.com...
Found com.github.homebysix.download.WordPress.com in recipe map
**load_recipe time: 0.011924000002181856
Processing WordPress.com.munki.recipe...
WARNING: WordPress.com.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (download_path): rest/v1.1/desktop/osx-silicon/download?type=dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 11 Sep 2024 17:46:56 GMT
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.4B39xx/WordPress.com.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.4B39xx/WordPress.com.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.4B39xx/WordPress.com.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg
Versioner: Found version 8.0.4 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg/WordPress.com.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/WordPress.com/WordPress.com-8.0.4-arm64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/WordPress.com/WordPress.com-8.0.4__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/receipts/WordPress.com.munki-receipt-20250901-152051.plist

The following new items were downloaded:
    Download Path                                                                                                  
    -------------                                                                                                  
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg  

The following new items were imported into Munki:
    Name           Version  Catalogs  Pkginfo Path                                        Pkg Repo Path                                  Icon Repo Path  
    ----           -------  --------  ------------                                        -------------                                  --------------  
    WordPress.com  8.0.4    testing   apps/WordPress.com/WordPress.com-8.0.4-arm64.plist  apps/WordPress.com/WordPress.com-8.0.4__1.dmg                  
```

```
autopkg run -v WordPress.com.munki.recipe
Looking for com.github.homebysix.download.WordPress.com...
Did not find com.github.homebysix.download.WordPress.com in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.homebysix.download.WordPress.com...
Found com.github.homebysix.download.WordPress.com in recipe map
**load_recipe time: 0.011117624999315012
Processing WordPress.com.munki.recipe...
WARNING: WordPress.com.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (download_path): rest/v1.1/desktop/osx/download?type=dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 11 Sep 2024 17:46:31 GMT
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.55c53p/WordPress.com.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.55c53p/WordPress.com.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.55c53p/WordPress.com.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg
Versioner: Found version 8.0.4 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg/WordPress.com.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/WordPress.com/WordPress.com-8.0.4-x86_64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/WordPress.com/WordPress.com-8.0.4.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/receipts/WordPress.com.munki-receipt-20250901-153051.plist

The following new items were downloaded:
    Download Path                                                                                                  
    -------------                                                                                                  
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.WordPress.com/downloads/WordPress.com.dmg  

The following new items were imported into Munki:
    Name           Version  Catalogs  Pkginfo Path                                         Pkg Repo Path                               Icon Repo Path  
    ----           -------  --------  ------------                                         -------------                               --------------  
    WordPress.com  8.0.4    testing   apps/WordPress.com/WordPress.com-8.0.4-x86_64.plist  apps/WordPress.com/WordPress.com-8.0.4.dmg 
```