### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Renamer/Renamer.download.recipe
+++ b/Renamer/Renamer.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>Renamer</string>
 		<key>URL</key>
-		<string>http://creativebe.com/download/renamer</string>
+		<string>https://creativebe.com/download/renamer</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>

--- a/ShareMouse/ShareMouse.download.recipe
+++ b/ShareMouse/ShareMouse.download.recipe
@@ -23,7 +23,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>http://www.keyboard-and-mouse-sharing.com/ShareMouseSetup.dmg</string>
+				<string>https://www.keyboard-and-mouse-sharing.com/ShareMouseSetup.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Tinderbox/Tinderbox.download.recipe
+++ b/Tinderbox/Tinderbox.download.recipe
@@ -38,7 +38,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>http://www.eastgate.com/%urlpath%</string>
+				<string>https://www.eastgate.com/%urlpath%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._