### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AirServer/AirServer.pkg.recipe
+++ b/AirServer/AirServer.pkg.recipe
@@ -82,8 +82,6 @@
 					</array>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/BetterTouchTool/BetterTouchTool.pkg.recipe
+++ b/BetterTouchTool/BetterTouchTool.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/BetterWindowManager/BetterWindowManager.pkg.recipe
+++ b/BetterWindowManager/BetterWindowManager.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Bjango/SkalaColor.pkg.recipe
+++ b/Bjango/SkalaColor.pkg.recipe
@@ -75,8 +75,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Bjango/SkalaPreview.pkg.recipe
+++ b/Bjango/SkalaPreview.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/BlackPixel/ForkLift.pkg.recipe
+++ b/BlackPixel/ForkLift.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/BohemianCoding/Sketch.pkg.recipe
+++ b/BohemianCoding/Sketch.pkg.recipe
@@ -71,8 +71,6 @@
 					</array>
 					<key>id</key>
 					<string>com.bohemiancoding.sketch3</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/C-Command/DropDMG.pkg.recipe
+++ b/C-Command/DropDMG.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>com.c-command.DropDMG</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/CharlesSoft/CocoaTADS.pkg.recipe
+++ b/CharlesSoft/CocoaTADS.pkg.recipe
@@ -86,8 +86,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/CharlesSoft/NibUnlocker.pkg.recipe
+++ b/CharlesSoft/NibUnlocker.pkg.recipe
@@ -75,8 +75,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/CharlesSoft/TimeTracker.pkg.recipe
+++ b/CharlesSoft/TimeTracker.pkg.recipe
@@ -75,8 +75,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/Chat/Chat.pkg.recipe
+++ b/Chat/Chat.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Clarify/Clarify.pkg.recipe
+++ b/Clarify/Clarify.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/CocoaPods/CocoaPods.pkg.recipe
+++ b/CocoaPods/CocoaPods.pkg.recipe
@@ -73,8 +73,6 @@ ln -sf /Applications/CocoaPods.app/Contents/Helpers/pod /usr/local/bin/pod</stri
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Corel/CorelProduct.pkg.recipe
+++ b/Corel/CorelProduct.pkg.recipe
@@ -167,8 +167,6 @@ installer -tgt "$3" -pkg "$3/private/tmp/%product_code%.pkg" -applyChoiceChanges
 				<dict>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/DeliciousMonster/DeliciousLibrary.pkg.recipe
+++ b/DeliciousMonster/DeliciousLibrary.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Divvy/Divvy.pkg.recipe
+++ b/Divvy/Divvy.pkg.recipe
@@ -86,8 +86,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/DuetDisplay/duet.pkg.recipe
+++ b/DuetDisplay/duet.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Eclipse/Eclipse.pkg.recipe
+++ b/Eclipse/Eclipse.pkg.recipe
@@ -90,8 +90,6 @@
 					</array>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/EclipseLuna/EclipseLuna.pkg.recipe
+++ b/EclipseLuna/EclipseLuna.pkg.recipe
@@ -86,8 +86,6 @@
 					</array>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Endurance/Endurance.pkg.recipe
+++ b/Endurance/Endurance.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/FatCatSoftware/PlistEditPro.pkg.recipe
+++ b/FatCatSoftware/PlistEditPro.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/FatCatSoftware/PowerPhotos.pkg.recipe
+++ b/FatCatSoftware/PowerPhotos.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/FatCatSoftware/PowerTunes.pkg.recipe
+++ b/FatCatSoftware/PowerTunes.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/FatCatSoftware/iPhotoLibraryManager.pkg.recipe
+++ b/FatCatSoftware/iPhotoLibraryManager.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/FindAnyFile/FindAnyFile.pkg.recipe
+++ b/FindAnyFile/FindAnyFile.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Flashlight/Flashlight.pkg.recipe
+++ b/Flashlight/Flashlight.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Flux/Flux.pkg.recipe
+++ b/Flux/Flux.pkg.recipe
@@ -86,8 +86,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/FlyingMeat/Acorn.pkg.recipe
+++ b/FlyingMeat/Acorn.pkg.recipe
@@ -41,8 +41,6 @@ The BUNDLE_ID variable may need to be changed when a new major version is releas
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Focus/Focus.pkg.recipe
+++ b/Focus/Focus.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Folio/Folio.pkg.recipe
+++ b/Folio/Folio.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/FontNuke/FontNuke.pkg.recipe
+++ b/FontNuke/FontNuke.pkg.recipe
@@ -54,8 +54,6 @@ This set of recipes differs from the one in wardsparadox-recipes because it prov
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/GasMask/GasMask.pkg.recipe
+++ b/GasMask/GasMask.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/GeometersSketchpad5/GSP5.pkg.recipe
+++ b/GeometersSketchpad5/GSP5.pkg.recipe
@@ -80,8 +80,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/GitHub/GitHubCLI.pkg.recipe
+++ b/GitHub/GitHubCLI.pkg.recipe
@@ -98,8 +98,6 @@
 					</array>
 					<key>id</key>
 					<string>com.github.cli</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>GitHubCLI-%version%</string>
 					<key>pkgroot</key>

--- a/GitHub/GitHubDesktop.pkg.recipe
+++ b/GitHub/GitHubDesktop.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%BUILD%-%version%</string>
 					<key>pkgroot</key>

--- a/Gitify/Gitify.pkg.recipe
+++ b/Gitify/Gitify.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/GoToMeeting/GoToMeeting.pkg.recipe
+++ b/GoToMeeting/GoToMeeting.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>com.citrixonline.GoToMeeting</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Goofy/Goofy.pkg.recipe
+++ b/Goofy/Goofy.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Google/GoogleChat.pkg.recipe
+++ b/Google/GoogleChat.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>com.google.chat</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Grammarly/Grammarly.pkg.recipe
+++ b/Grammarly/Grammarly.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>com.grammarly.ProjectLlama</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Helium/Helium.pkg.recipe
+++ b/Helium/Helium.pkg.recipe
@@ -63,8 +63,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/HocusFocus/HocusFocus.pkg.recipe
+++ b/HocusFocus/HocusFocus.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Houdah/HoudahGeo.pkg.recipe
+++ b/Houdah/HoudahGeo.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Houdah/HoudahSpot.pkg.recipe
+++ b/Houdah/HoudahSpot.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Houdah/Tembo.pkg.recipe
+++ b/Houdah/Tembo.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Iconfactory/xScope.pkg.recipe
+++ b/Iconfactory/xScope.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/InsiliCo/CodeCookbookforSwift.pkg.recipe
+++ b/InsiliCo/CodeCookbookforSwift.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/InsiliCo/iSwift.pkg.recipe
+++ b/InsiliCo/iSwift.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/IrradiatedSoftware/SwitchUp.pkg.recipe
+++ b/IrradiatedSoftware/SwitchUp.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/IrradiatedSoftware/Tickets.pkg.recipe
+++ b/IrradiatedSoftware/Tickets.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/IrradiatedSoftware/iClip.pkg.recipe
+++ b/IrradiatedSoftware/iClip.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Jin/Jin.pkg.recipe
+++ b/Jin/Jin.pkg.recipe
@@ -79,8 +79,6 @@
 					</array>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Karelia/Sandvox.pkg.recipe
+++ b/Karelia/Sandvox.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Kubernetes/kubectl.pkg.recipe
+++ b/Kubernetes/kubectl.pkg.recipe
@@ -98,8 +98,6 @@
 					</array>
 					<key>id</key>
 					<string>io.kubernetes.kubectl</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>kubectl-%version%</string>
 					<key>pkgroot</key>

--- a/LemkeSoft/GraphicConverter.pkg.recipe
+++ b/LemkeSoft/GraphicConverter.pkg.recipe
@@ -41,8 +41,6 @@ The MAJOR_VERSION input variable can be overridden to select the major version o
 					</array>
 					<key>id</key>
 					<string>com.lemkesoft.graphicconverter%MAJOR_VERSION%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/LiteratureAndLatte/Scapple.pkg.recipe
+++ b/LiteratureAndLatte/Scapple.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/LiteratureAndLatte/Scrivener.pkg.recipe
+++ b/LiteratureAndLatte/Scrivener.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/LiveSurfaceContext/LiveSurfaceContext.pkg.recipe
+++ b/LiveSurfaceContext/LiveSurfaceContext.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MacDVDRipperPro/MacDVDRipperPro.pkg.recipe
+++ b/MacDVDRipperPro/MacDVDRipperPro.pkg.recipe
@@ -44,8 +44,6 @@ This set of recipes differs from the ones provided by macvfx-recipes in the foll
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MacPaw/CleanMyMac2.pkg.recipe
+++ b/MacPaw/CleanMyMac2.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MacPaw/CleanMyMac3-beta.pkg.recipe
+++ b/MacPaw/CleanMyMac3-beta.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MacPaw/CleanMyMac3.pkg.recipe
+++ b/MacPaw/CleanMyMac3.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MacPaw/Hider2.pkg.recipe
+++ b/MacPaw/Hider2.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Mailplane/Mailplane3.pkg.recipe
+++ b/Mailplane/Mailplane3.pkg.recipe
@@ -95,8 +95,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/MartianCraft/Changes.pkg.recipe
+++ b/MartianCraft/Changes.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MerlinProject/MerlinProject.pkg.recipe
+++ b/MerlinProject/MerlinProject.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Metabase/Metabase.pkg.recipe
+++ b/Metabase/Metabase.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Monodraw/Monodraw.pkg.recipe
+++ b/Monodraw/Monodraw.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Monolingual/Monolingual.pkg.recipe
+++ b/Monolingual/Monolingual.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Mountain/Mountain.pkg.recipe
+++ b/Mountain/Mountain.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/NameChanger/NameChanger.pkg.recipe
+++ b/NameChanger/NameChanger.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/NeoFinder/NeoFinder.pkg.recipe
+++ b/NeoFinder/NeoFinder.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Noodlesoft/Hazel.pkg.recipe
+++ b/Noodlesoft/Hazel.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/Nordstrom/kubelogin.pkg.recipe
+++ b/Nordstrom/kubelogin.pkg.recipe
@@ -80,8 +80,6 @@
 					</array>
 					<key>id</key>
 					<string>com.nordstrom.kubelogin</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>kubelogin-%version%</string>
 					<key>pkgroot</key>

--- a/NothingMagical/Whiskey.pkg.recipe
+++ b/NothingMagical/Whiskey.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Numi/Numi.pkg.recipe
+++ b/Numi/Numi.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/OpenEmu/OpenEmu.pkg.recipe
+++ b/OpenEmu/OpenEmu.pkg.recipe
@@ -76,8 +76,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Paparazzi/Paparazzi.pkg.recipe
+++ b/Paparazzi/Paparazzi.pkg.recipe
@@ -75,8 +75,6 @@ NOTE: Cannot use AppPkgCreator for this recipe because the exclamation point in 
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Parallels/ParallelsDesktop.pkg.recipe
+++ b/Parallels/ParallelsDesktop.pkg.recipe
@@ -136,8 +136,6 @@ exit 0</string>
 					<array/>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Perforce/HelixALM.pkg.recipe
+++ b/Perforce/HelixALM.pkg.recipe
@@ -476,8 +476,6 @@ InstallSet: 'Client'
 					</array>
 					<key>id</key>
 					<string>com.perforce.HelixALMClient</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Perforce/P4V.pkg.recipe
+++ b/Perforce/P4V.pkg.recipe
@@ -84,8 +84,6 @@
 					</array>
 					<key>id</key>
 					<string>com.perforce.p4v</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Polymail/Polymail.pkg.recipe
+++ b/Polymail/Polymail.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/ProfitTrain/ProfitTrain.pkg.recipe
+++ b/ProfitTrain/ProfitTrain.pkg.recipe
@@ -52,8 +52,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/PublicSpace/ABetterFinderAttributes.pkg.recipe
+++ b/PublicSpace/ABetterFinderAttributes.pkg.recipe
@@ -39,8 +39,6 @@ The MAJOR_VERSION input variable can be overridden to determine which version of
 					</array>
 					<key>id</key>
 					<string>net.publicspace.abfa%MAJOR_VERSION%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/PublicSpace/ABetterFinderRename.pkg.recipe
+++ b/PublicSpace/ABetterFinderRename.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>net.publicspace.abfr%MAJOR_VERSION%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/PublicSpace/BigMeanFolderMachine.pkg.recipe
+++ b/PublicSpace/BigMeanFolderMachine.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/PublicSpace/MacBreakZ.pkg.recipe
+++ b/PublicSpace/MacBreakZ.pkg.recipe
@@ -39,8 +39,6 @@ The MAJOR_VERSION input variable can be overridden to determine which version of
 					</array>
 					<key>id</key>
 					<string>net.publicspace.mb%MAJOR_VERSION%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/PublicSpace/NoiseMachine.pkg.recipe
+++ b/PublicSpace/NoiseMachine.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/PublicSpace/VitaminR.pkg.recipe
+++ b/PublicSpace/VitaminR.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Radi/Radi.pkg.recipe
+++ b/Radi/Radi.pkg.recipe
@@ -63,8 +63,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RagingMenace/MenuMeters.pkg.recipe
+++ b/RagingMenace/MenuMeters.pkg.recipe
@@ -54,8 +54,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RainerBrockerhoff/RBAppCheckerLite.pkg.recipe
+++ b/RainerBrockerhoff/RBAppCheckerLite.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RainerBrockerhoff/RBAppQuarantine.pkg.recipe
+++ b/RainerBrockerhoff/RBAppQuarantine.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RealMac/DeepDreamer.pkg.recipe
+++ b/RealMac/DeepDreamer.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RealMac/RapidWeaver.pkg.recipe
+++ b/RealMac/RapidWeaver.pkg.recipe
@@ -39,8 +39,6 @@ The MAJOR_VERSION input variable can be overridden to determine which version of
 					</array>
 					<key>id</key>
 					<string>com.realmacsoftware.rapidweaver%MAJOR_VERSION%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RecordIt/RecordIt.pkg.recipe
+++ b/RecordIt/RecordIt.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Renamer/Renamer.pkg.recipe
+++ b/Renamer/Renamer.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Resilio/ResilioSync.pkg.recipe
+++ b/Resilio/ResilioSync.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RightFont/RightFont.pkg.recipe
+++ b/RightFont/RightFont.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RogueAmoeba/AirFoil.pkg.recipe
+++ b/RogueAmoeba/AirFoil.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RogueAmoeba/AudioHijack.pkg.recipe
+++ b/RogueAmoeba/AudioHijack.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RogueAmoeba/Fission.pkg.recipe
+++ b/RogueAmoeba/Fission.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/RogueAmoeba/Piezo.pkg.recipe
+++ b/RogueAmoeba/Piezo.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SaveHollywood/SaveHollywood.pkg.recipe
+++ b/SaveHollywood/SaveHollywood.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SelfControl/SelfControl.pkg.recipe
+++ b/SelfControl/SelfControl.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Shimo/Shimo.pkg.recipe
+++ b/Shimo/Shimo.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/ShirtPocket/SuperDuper.pkg.recipe
+++ b/ShirtPocket/SuperDuper.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/SizeUp/SizeUp.pkg.recipe
+++ b/SizeUp/SizeUp.pkg.recipe
@@ -86,8 +86,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/Slack/nebula.pkg.recipe
+++ b/Slack/nebula.pkg.recipe
@@ -98,8 +98,6 @@
 					</array>
 					<key>id</key>
 					<string>com.slack.nebula</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>nebula-%version%</string>
 					<key>pkgroot</key>

--- a/Sparkle/Sparkle.pkg.recipe
+++ b/Sparkle/Sparkle.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Spotify/Spotify.pkg.recipe
+++ b/Spotify/Spotify.pkg.recipe
@@ -80,8 +80,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/StairwaysSoftware/KeyboardMaestro.pkg.recipe
+++ b/StairwaysSoftware/KeyboardMaestro.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/StretchLink/StretchLink.pkg.recipe
+++ b/StretchLink/StretchLink.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SuperMegaUltraGroovy/Capo.pkg.recipe
+++ b/SuperMegaUltraGroovy/Capo.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SuperMegaUltraGroovy/TapeDeck.pkg.recipe
+++ b/SuperMegaUltraGroovy/TapeDeck.pkg.recipe
@@ -52,8 +52,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Tenor/GIFforMac.pkg.recipe
+++ b/Tenor/GIFforMac.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/TextBar/TextBar.pkg.recipe
+++ b/TextBar/TextBar.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Tower/Tower.pkg.recipe
+++ b/Tower/Tower.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Tracker/Tracker.pkg.recipe
+++ b/Tracker/Tracker.pkg.recipe
@@ -80,8 +80,6 @@ The Tracker app requires Apple's legacy Java 6 installer. The pkg installer gene
 					</array>
 					<key>id</key>
 					<string>org.opensourcephysics.cabrillo.tracker</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Tunabelly/SilentStart.pkg.recipe
+++ b/Tunabelly/SilentStart.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/TunnelBear/TunnelBear.pkg.recipe
+++ b/TunnelBear/TunnelBear.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Tunnelblick/Tunnelblick.pkg.recipe
+++ b/Tunnelblick/Tunnelblick.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Unmarked/TextSoap.pkg.recipe
+++ b/Unmarked/TextSoap.pkg.recipe
@@ -41,8 +41,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/ViennaRSS/Vienna.pkg.recipe
+++ b/ViennaRSS/Vienna.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/VimR/VimR.pkg.recipe
+++ b/VimR/VimR.pkg.recipe
@@ -52,8 +52,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/VirtualHost/VirtualHostX.pkg.recipe
+++ b/VirtualHost/VirtualHostX.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Vivaldi/Vivaldi.pkg.recipe
+++ b/Vivaldi/Vivaldi.pkg.recipe
@@ -80,8 +80,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Vox/Vox.pkg.recipe
+++ b/Vox/Vox.pkg.recipe
@@ -41,8 +41,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Wireshark/Wireshark.pkg.recipe
+++ b/Wireshark/Wireshark.pkg.recipe
@@ -69,8 +69,6 @@
 					</array>
 					<key>id</key>
 					<string>org.wireshark.Wireshark.pkg</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 				</dict>

--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -91,8 +91,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/cdto/cdto.pkg.recipe
+++ b/cdto/cdto.pkg.recipe
@@ -52,8 +52,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>cdto-%version%</string>
 					<key>pkgroot</key>

--- a/iNotepad/iNotepad.pkg.recipe
+++ b/iNotepad/iNotepad.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/soma-zone/Ammonite.pkg.recipe
+++ b/soma-zone/Ammonite.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/soma-zone/BackupLoupe.pkg.recipe
+++ b/soma-zone/BackupLoupe.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/soma-zone/LaunchControl.pkg.recipe
+++ b/soma-zone/LaunchControl.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/uBar/uBar.pkg.recipe
+++ b/uBar/uBar.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._