### PR TITLE
Move `pkgname` key into `pkg_request` dictionary of PkgCreator arguments

### DIFF
--- a/Wireshark/Wireshark.pkg.recipe
+++ b/Wireshark/Wireshark.pkg.recipe
@@ -71,9 +71,9 @@
 					<string>org.wireshark.Wireshark.pkg</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%ARCH%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%ARCH%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
Although `pkgname` can technically live anywhere within the AutoPkg recipe since it can be read from the environment, it's conventional to put it where it's directly accessed: in the `pkg_request` dictionary alongside `version`, `id`, and other keys.

This PR makes that adjustment. Thanks for considering!

_Submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._