### PR TITLE
Update RightFont.munki recipe

### DIFF
--- a/RightFont/RightFont.munki.recipe
+++ b/RightFont/RightFont.munki.recipe
@@ -58,6 +58,8 @@
 				<string>%dmg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
Change the version comparison logic: vendor is not reliably updating CFBundleShortVersionString when revising the app,but appears to be predictably incrementing CFBundleVersion