### PR TITLE
Removed unused %ARCH% variable in pkg name causing "Error in com.git…

### DIFF
--- a/Wireshark/Wireshark.pkg.recipe
+++ b/Wireshark/Wireshark.pkg.recipe
@@ -72,7 +72,7 @@
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>
-					<string>%NAME%-%ARCH%-%version%</string>
+					<string>%NAME%-%version%</string>
 				</dict>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
This pull request removes the unused %ARCH% variable in pkg name causing "Error in com.github.homebysix.pkg.Wireshark: Processor: PkgCreator: Error: Invalid package name"
