### PR TITLE
Add MunkiPkginfoMerger to recipe processors

### DIFF
--- a/GitHub/GitHubCLI.munki.recipe
+++ b/GitHub/GitHubCLI.munki.recipe
@@ -65,6 +65,10 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>additional_pkginfo</key>


### PR DESCRIPTION
Hi, @homebysix 

This PR adds in the MunkiPkginfoMerger processor in the GitHubCLI.munki.recipe to ensure proper Installs Array creation, as it was being overwritten by the MunkiPkginfoMerger step with supported_architectures in. 