### PR TITLE
Add architecture support to Greenfoot recipes

### DIFF
--- a/greenfoot/Greenfoot.download.recipe
+++ b/greenfoot/Greenfoot.download.recipe
@@ -3,11 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of Greenfoot</string>
+	<string>Downloads the current release version of Greenfoot
+
+To download Apple Silicon use: "aarch64" in the DOWNLOAD_ARCH variable
+To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Greenfoot</string>
 	<key>Input</key>
 	<dict>
+		<key>DOWNLOAD_ARCH</key>
+		<string>aarch64</string>
 		<key>NAME</key>
 		<string>Greenfoot</string>
 	</dict>
@@ -19,7 +24,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https://www.greenfoot.org/download/files/Greenfoot-mac-[\S]+.dmg</string>
+				<string>https://www.greenfoot.org/download/files/Greenfoot-mac-%DOWNLOAD_ARCH%-[A-Za-z0-9]+.dmg</string>
 				<key>url</key>
 				<string>https://www.greenfoot.org/download</string>
 			</dict>

--- a/greenfoot/Greenfoot.munki.recipe
+++ b/greenfoot/Greenfoot.munki.recipe
@@ -5,7 +5,10 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Greenfoot and imports it into Munki.</string>
+	<string>Downloads the latest version of Greenfoot and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.greenfoot</string>
 	<key>Input</key>
@@ -14,6 +17,8 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>Greenfoot</string>
+		<key>SUPPORTED_ARCH</key>
+		<string>arm64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -28,6 +33,10 @@
 			<string>Greenfoot</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>


### PR DESCRIPTION
Hi, @homebysix 

The current GreenFoot download recipe grabs the arm64 version. This PR adds support for arch specific downloads to the download and Munki recipes.  

Output from successful -v runs
```
autopkg run -v Greenfoot.munki.recipe 
Processing Greenfoot.munki.recipe...
WARNING: Greenfoot.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://www.greenfoot.org/download/files/Greenfoot-mac-x64-390.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Sun, 03 Nov 2024 16:49:50 GMT
URLDownloader: Storing new ETag header: "b02f822-62604f4db4780"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-x64-390.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-x64-390.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.jlQdv6/Greenfoot.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.jlQdv6/Greenfoot.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.jlQdv6/Greenfoot.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-x64-390.dmg
Versioner: Found version 3.9.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-x64-390.dmg/Greenfoot.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Greenfoot/Greenfoot-3.9.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Greenfoot/Greenfoot-mac-x64-390-3.9.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/receipts/Greenfoot.munki-receipt-20260112-124531.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-x64-390.dmg  

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                          Pkg Repo Path                                   Icon Repo Path  
    ----       -------  --------  ------------                          -------------                                   --------------  
    Greenfoot  3.9.0    testing   apps/Greenfoot/Greenfoot-3.9.0.plist  apps/Greenfoot/Greenfoot-mac-x64-390-3.9.0.dmg
```

```
autopkg run -v Greenfoot.munki.recipe
Processing Greenfoot.munki.recipe...
WARNING: Greenfoot.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://www.greenfoot.org/download/files/Greenfoot-mac-aarch64-390.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Sun, 03 Nov 2024 17:20:20 GMT
URLDownloader: Storing new ETag header: "ac7fb5f-6260561eedd00"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-aarch64-390.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-aarch64-390.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.1iSajy/Greenfoot.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.1iSajy/Greenfoot.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.1iSajy/Greenfoot.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-aarch64-390.dmg
Versioner: Found version 3.9.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-aarch64-390.dmg/Greenfoot.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Greenfoot/Greenfoot-3.9.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Greenfoot/Greenfoot-mac-aarch64-390-3.9.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/receipts/Greenfoot.munki-receipt-20260112-124831.plist

The following new items were downloaded:
    Download Path                                                                                                          
    -------------                                                                                                          
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.greenfoot/downloads/Greenfoot-mac-aarch64-390.dmg  

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                             Pkg Repo Path                                       Icon Repo Path  
    ----       -------  --------  ------------                             -------------                                       --------------  
    Greenfoot  3.9.0    testing   apps/Greenfoot/Greenfoot-3.9.0__1.plist  apps/Greenfoot/Greenfoot-mac-aarch64-390-3.9.0.dmg
```