### PR TITLE
Add install and uninstall scripts for Docker Desktop

### DIFF
--- a/Docker/DockerDesktop.munki.recipe
+++ b/Docker/DockerDesktop.munki.recipe
@@ -28,6 +28,100 @@
 			<string>Docker</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/bash
+
+# This is to allow for installation without admin credentials being needed.
+# https://docs.docker.com/desktop/setup/install/mac-install/#installer-flags
+# https://docs.docker.com/desktop/setup/install/mac-permission-requirements/
+
+# Get current console user
+CONSOLE_USER=$(/usr/bin/stat -f%Su /dev/console)
+
+if [ "$CONSOLE_USER" != "root" ] &amp;&amp; [ -n "$CONSOLE_USER" ]; then
+	echo "Installing Docker Desktop for user: $CONSOLE_USER"
+	/Applications/Docker.app/Contents/MacOS/install --accept-license --user="$CONSOLE_USER"
+else
+	echo "No user logged in, cannot complete Docker Desktop installation"
+	exit 1
+fi
+
+exit 0</string>
+			<key>postuninstall_script</key>
+			<string>#!/bin/bash
+
+# Remove system-level Docker Desktop files that could be left over after running /Applications/Docker.app/Contents/MacOS/uninstall
+# https://docs.docker.com/desktop/uninstall/#from-the-cli
+# https://docs.docker.com/desktop/setup/install/mac-permission-requirements/
+# https://docs.docker.com/desktop/setup/install/mac-install/
+
+
+# Exit on any error
+set -e
+
+echo "Starting Docker Desktop system-level cleanup..."
+
+# Array of system-wide Docker files to clean up
+DOCKER_PATHS=(
+	"/Library/Application Support/com.docker.docker"
+	"/Library/LaunchDaemons/com.docker.socket.plist"
+	"/Library/LaunchDaemons/com.docker.vmnetd.plist"
+	"/Library/Logs/com.docker.dockerd.log"
+	"/Library/Logs/Docker Desktop"
+	"/Library/PrivilegedHelperTools/com.docker.hyperkit"
+	"/Library/PrivilegedHelperTools/com.docker.socket"
+	"/Library/PrivilegedHelperTools/com.docker.vmnetd"
+	"/private/var/run/docker.sock"
+	"/private/var/tmp/com.docker.vmnetd.socket"
+	"/usr/local/bin/docker-compose"
+	"/usr/local/bin/docker-credential-desktop"
+	"/usr/local/bin/docker-credential-ecr-login"
+	"/usr/local/bin/docker-credential-osxkeychain"
+	"/usr/local/bin/docker"
+	"/usr/local/bin/hyperkit"
+	"/usr/local/bin/kubectl.docker"
+	"/usr/local/bin/kubectl"
+	"/usr/local/bin/vpnkit"
+)
+
+# Function to remove a files if they exists
+safe_remove() {
+	if [ -e "$1" ]; then
+		echo "Removing: $1"
+		rm -rf "$1"
+	fi
+}
+
+# Clean up system-wide Docker files
+for path in "${DOCKER_PATHS[@]}"; do
+	safe_remove "$path"
+done
+
+echo "Docker Desktop system-level cleanup complete!"
+
+exit 0</string>
+			<key>preuninstall_script</key>
+			<string>#!/bin/bash
+
+# Call the vendors uninstall binary - closes the app, removes system files and unloads launch daemon.
+# https://docs.docker.com/desktop/uninstall/#from-the-cli
+
+# Run the uninstall binary
+/Applications/Docker.app/Contents/MacOS/uninstall
+
+# Remove Docker-related host entries
+# /Volumes/Docker/Docker.app/Contents/MacOS/install --help
+
+# remove-kube-host removes kubernetes.docker.internal from /etc/hosts
+/Applications/Docker.app/Contents/MacOS/install remove-kube-host
+
+# unregisters the startup task for the docker socket symlink
+/Applications/Docker.app/Contents/MacOS/install remove-socket-symlink-on-startup
+
+# Removes the vmnetd privileged process used for port binding
+/Applications/Docker.app/Contents/MacOS/install remove-vmnetd
+
+exit 0</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>
@@ -40,6 +134,59 @@
 	<string>com.github.homebysix.download.DockerDesktop</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>installcheck_script</key>
+					<string>#!/bin/bash
+
+# Install Check Script to ensure install only happens with a logged in user. This is to allow for installation without admin credentials being needed.
+# https://docs.docker.com/desktop/setup/install/mac-permission-requirements/
+# https://docs.docker.com/desktop/setup/install/mac-install/
+
+# Target version
+TARGET_VERSION="%version%"
+
+# Get current console user
+CONSOLE_USER=$(/usr/bin/stat -f%Su /dev/console)
+
+# Check if we're at login window or no user logged in
+if [ "$CONSOLE_USER" = "root" ] || [ -z "$CONSOLE_USER" ]; then
+	echo "No user logged in or at login window. Deferring installation."
+	exit 1
+fi
+
+# Check if Docker.app exists
+if [ -d "/Applications/Docker.app" ]; then
+	# Get current version from Docker.app
+	CURRENT_VERSION=$(/usr/bin/defaults read "/Applications/Docker.app/Contents/Info.plist" CFBundleShortVersionString 2&gt;/dev/null)
+
+	if [ -n "$CURRENT_VERSION" ]; then
+		echo "Current Docker version: $CURRENT_VERSION"
+
+		# Compare versions
+		if [[ "$CURRENT_VERSION" = "$TARGET_VERSION" ]]; then
+			echo "Docker is already at version $TARGET_VERSION"
+			exit 1
+		elif [[ "$CURRENT_VERSION" &gt; "$TARGET_VERSION" ]]; then
+			echo "Current Docker version ($CURRENT_VERSION) is newer than $TARGET_VERSION"
+			exit 1
+		fi
+	fi
+fi
+
+echo "User $CONSOLE_USER is logged in and Docker needs updating. OK to proceed with installation."
+
+exit 0</string>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Hi, @homebysix 

I'd noticed this issue https://github.com/autopkg/homebysix-recipes/issues/638 when I checked there wasn't anything pending for the GreenFoot PR I just raised, and thought I'd PR what we've been using for Docker. 

This adds in postinstall, preuninstall, and postuninstall scripts to handle Docker Desktop installation and cleanup without requiring admin credentials, and to ensure proper removal of system files. As there needs to be a logged in user this also adds an installcheck_script to defer installation if no user is logged in or if the correct version is already installed.

Output from a successful -v run 
```
autopkg run -v DockerDesktop.munki.recipe 
Processing DockerDesktop.munki.recipe...
WARNING: DockerDesktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://desktop.docker.com/mac/main/amd64/214940/Docker.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 07 Jan 2026 11:57:50 GMT
URLDownloader: Storing new ETag header: "fd49fb8b2055cd54f2176fd01dc53fd1"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.aBq3z6/Docker.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.aBq3z6/Docker.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.aBq3z6/Docker.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg
Versioner: Found version 4.56.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg/Docker.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installcheck_script': '#!/bin/bash\n\n# Install Check Script to ensure install only happens with a logged in user. This is to allow for installation without admin credentials being needed.\n# https://docs.docker.com/desktop/setup/install/mac-permission-requirements/\n# https://docs.docker.com/desktop/setup/install/mac-install/\n\n# Target version\nTARGET_VERSION="4.56.0"\n\n# Get current console user\nCONSOLE_USER=$(/usr/bin/stat -f%Su /dev/console)\n\n# Check if we\'re at login window or no user logged in\nif [ "$CONSOLE_USER" = "root" ] || [ -z "$CONSOLE_USER" ]; then\n\techo "No user logged in or at login window. Deferring installation."\n\texit 1\nfi\n\n# Check if Docker.app exists\nif [ -d "/Applications/Docker.app" ]; then\n\t# Get current version from Docker.app\n\tCURRENT_VERSION=$(/usr/bin/defaults read "/Applications/Docker.app/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null)\n\n\tif [ -n "$CURRENT_VERSION" ]; then\n\t\techo "Current Docker version: $CURRENT_VERSION"\n\n\t\t# Compare versions\n\t\tif [[ "$CURRENT_VERSION" = "$TARGET_VERSION" ]]; then\n\t\t\techo "Docker is already at version $TARGET_VERSION"\n\t\t\texit 1\n\t\telif [[ "$CURRENT_VERSION" > "$TARGET_VERSION" ]]; then\n\t\t\techo "Current Docker version ($CURRENT_VERSION) is newer than $TARGET_VERSION"\n\t\t\texit 1\n\t\tfi\n\tfi\nfi\n\necho "User $CONSOLE_USER is logged in and Docker needs updating. OK to proceed with installation."\n\nexit 0', 'version': '4.56.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Docker/Docker-4.56.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Docker/Docker-amd64-4.56.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/receipts/DockerDesktop.munki-receipt-20260112-131834.plist

The following new items were downloaded:
    Download Path                                                                                                 
    -------------                                                                                                 
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.homebysix.munki.DockerDesktop/downloads/Docker-amd64.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                     Pkg Repo Path                        Icon Repo Path  
    ----    -------  --------  ------------                     -------------                        --------------  
    Docker  4.56.0   testing   apps/Docker/Docker-4.56.0.plist  apps/Docker/Docker-amd64-4.56.0.dmg
```