### PR TITLE
Update DockerDesktop.munki.recipe

### DIFF
--- a/Docker/DockerDesktop.munki.recipe
+++ b/Docker/DockerDesktop.munki.recipe
@@ -107,9 +107,6 @@ exit 0</string>
 # https://docs.docker.com/desktop/setup/install/mac-permission-requirements/
 # https://docs.docker.com/desktop/setup/install/mac-install/
 
-# Target version
-TARGET_VERSION="%version%"
-
 # Get current console user
 CONSOLE_USER=$(/usr/bin/stat -f%Su /dev/console)
 


### PR DESCRIPTION
CC: @paul-cossey

This updates the Docker Munki recipe so it doesn't have a hard-coded `installcheck_script` that cannot be overridden.

It moves the "is a user logged in logic" to a `preinstall_script` that accomplishes the same goal.

This allows Munki to continue using the `installs` array to validate the correct version is installed instead of having to add that logic to a hard-coded `installcheck_script` in order to pass the version number variable.

I blogged about this approach a couple years back: https://www.kevinmcox.com/2022/12/deploying-docker-desktop-4-15-with-munki/

The end result is that no one is forced to use any of the script logic and can easily make local changes they want in their override.