### PR TITLE
Update DockerDesktop.munki.recipe

### DIFF
--- a/Docker/DockerDesktop.munki.recipe
+++ b/Docker/DockerDesktop.munki.recipe
@@ -56,9 +56,6 @@ exit 0</string>
 # https://docs.docker.com/desktop/setup/install/mac-install/
 
 
-# Exit on any error
-set -e
-
 echo "Starting Docker Desktop system-level cleanup..."
 
 # Array of system-wide Docker files to clean up


### PR DESCRIPTION
This removes the `set -e` during the postuninstall_script. While I believe it is unlikely for the script to fail, there is not much benefit of having the entire script fail due to an error.