### PR TITLE
Add Architecture as input variable and to the Regex

### DIFF
--- a/Papers/Papers.download.recipe
+++ b/Papers/Papers.download.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Papers.</string>
+	<string>Downloads the latest version of Papers.
+		Supported values for PLATFORM_ARCH include:
+		- arm64 (Apple Silicon)
+		- x64 (Intel, default)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Papers</string>
 	<key>Input</key>


### PR DESCRIPTION
So far this recipe only downloaded Intel version of the App.

This PR updates the AutoPkg recipe to introduce a new PLATFORM_ARCH input variable.

The variable is referenced within the download regex, allowing the recipe to dynamically match builds based on the specified architecture.

Changes:
	•	Added an PLATFORM_ARCH input variable
	•	Updated the regex to reference the ARCHITECTURE variable
	•	Ensured compatibility for both x64 and arm64 builds

This change enables support for downloading architecture-specific versions of the application. It allows separate overrides to specify x64 or arm64, making the recipe more flexible.