### PR TITLE
Replace Developer name

### DIFF
--- a/Papers/Papers.munki.recipe
+++ b/Papers/Papers.munki.recipe
@@ -23,7 +23,7 @@
 			<key>description</key>
 			<string>Your personal library of scientific resources.</string>
 			<key>developer</key>
-			<string>mekentosj.com</string>
+			<string>Digital Science Research and Solutions Inc.</string>
 			<key>display_name</key>
 			<string>Papers</string>
 			<key>name</key>


### PR DESCRIPTION
mekentosj seems to be the Github Account name for the Digital Science Research and Solutions Inc..
But mekentosj.com redirects to https://conexaoeducativa.novaescola.org.br/ , which does not seem to belong to the Digital Science Research and Solutions Inc.

I would suggest changing the Developer name to Digital Science Research and Solutions Inc.