### PR TITLE
R.munki: Use detected %version% from download recipe

### DIFF
--- a/R/R.munki.recipe
+++ b/R/R.munki.recipe
@@ -101,6 +101,8 @@ NOTE: If you change the ARCH variable, be sure to also include a corresponding '
 				<dict>
 					<key>minimum_os_version</key>
 					<string>%min_os_ver%</string>
+					<key>version</key>
+					<string>%version%</string>
 				</dict>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
There are four receipts in the pkg:
> org.R-project.arm64.R.fw.pkg 4.5.3
> org.R-project.arm64.R.GUI.pkg 1.82
> org.r-project.arm64.tcltk 8.6.13
> org.r-project.arm64.texinfo 6.8

MunkiImporter decides to use the tcltk version for the pkginfo, leading to 4.5.2 being imported as R-8.6.13.plist and 4.5.3 being imported as R-8.6.13__1.plist.

This changes the recipe to use the detected `%version%` from the download recipe, resulting in R-4.5.2.plist and R-4.5.3.plist.

autopkg run still detects R-8.6.13__1.plist as the same as R-4.5.3.plist and this hopefully shouldn't cause any duplicate imports.