### PR TITLE
Add Platform Architecture to Url Text Searcher

### DIFF
--- a/Papers/Papers.download.recipe
+++ b/Papers/Papers.download.recipe
@@ -40,7 +40,7 @@
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>https://update.readcube.com/desktop/updates/Papers_Setup_%version%-x64.dmg</string>
+				<string>https://update.readcube.com/desktop/updates/Papers_Setup_%version%-%PLATFORM_ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
During testing, we identified that the URLTextSearcher processor also requires %PLATFORM_ARCH% as a variable reference, rather than a hardcoded architecture value, in order to match and download the correct DMG file.