### PR TITLE
Add ARCH input to Polypane download recipe

### DIFF
--- a/Firstversionist/Polypane.download.recipe
+++ b/Firstversionist/Polypane.download.recipe
@@ -5,13 +5,15 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.3 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Polypane.</string>
+	<string>Downloads the latest version of Polypane. ARCH may be set to "universal" (default), "arm64", or blank for Intel-only.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Polypane</string>
 	<key>Input</key>
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>polypane</string>
+		<key>ARCH</key>
+		<string>universal</string>
 		<key>NAME</key>
 		<string>Polypane</string>
 	</dict>
@@ -23,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>.*\.dmg$</string>
+				<string>Polypane-[\d.]+-?%ARCH%\.dmg$</string>
 				<key>github_repo</key>
 				<string>firstversionist/polypane</string>
 			</dict>


### PR DESCRIPTION
## Summary

Polypane now publishes three macOS DMGs per release on GitHub:
- `Polypane-X.Y.Z-universal.dmg` (universal)
- `Polypane-X.Y.Z-arm64.dmg` (Apple Silicon)
- `Polypane-X.Y.Z.dmg` (Intel)

The current `asset_regex` (`.*\.dmg$`) matches all three, so `GitHubReleasesInfoProvider` nondeterministically picks whichever sorts first alphabetically (currently the arm64 DMG).

This PR adds an `ARCH` input variable (default: `universal`) and updates the `asset_regex` to target the correct DMG based on the selected architecture.

### Valid `ARCH` values
| Value | Downloads |
|---|---|
| `universal` (default) | Universal binary |
| `arm64` | Apple Silicon only |
| *(blank)* | Intel only |

### Testing

```
$ autopkg run -vvq Polypane.download --check

Processing Polypane.download.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Polypane-[\\d.]+-?universal\\.dmg$',
           'github_repo': 'firstversionist/polypane'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: <REDACTED>
GitHubReleasesInfoProvider: No value supplied for GITHUB_RELEASES_PER_PAGE, setting default value of: 30
GitHubReleasesInfoProvider: Fetching page 1 of GitHub releases
GitHubReleasesInfoProvider: Matched regex 'Polypane-[\d.]+-?universal\.dmg$' among asset(s): latest-linux-arm64.yml, latest-linux.yml, latest-mac.yml, latest.yml, Polypane-28.0.3-arm64-mac.zip, Polypane-28.0.3-arm64-mac.zip.blockmap, Polypane-28.0.3-arm64.AppImage, Polypane-28.0.3-arm64.dmg, Polypane-28.0.3-arm64.dmg.blockmap, Polypane-28.0.3-mac.zip, Polypane-28.0.3-mac.zip.blockmap, Polypane-28.0.3-universal-mac.zip, Polypane-28.0.3-universal-mac.zip.blockmap, Polypane-28.0.3-universal.dmg, Polypane-28.0.3-universal.dmg.blockmap, Polypane-28.0.3.AppImage, Polypane-28.0.3.dmg, Polypane-28.0.3.dmg.blockmap, Polypane-Setup-28.0.3.exe, Polypane-Setup-28.0.3.exe.blockmap, polypane_28.0.3_amd64.deb, polypane_28.0.3_arm64.deb
GitHubReleasesInfoProvider: Selected asset 'Polypane-28.0.3-universal.dmg' from release 'v28.0.3'
{'Output': {'asset_created_at': '2026-03-10T13:53:46Z',
            'asset_url': 'https://api.github.com/repos/firstversionist/polypane/releases/assets/370844135',
            'release_notes': '<SNIP>',
            'url': 'https://github.com/firstversionist/polypane/releases/download/v28.0.3/Polypane-28.0.3-universal.dmg',
            'version': '28.0.3'}}
URLDownloader
{'Input': {'filename': 'Polypane-28.0.3.dmg',
           'url': 'https://github.com/firstversionist/polypane/releases/download/v28.0.3/Polypane-28.0.3-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded <CACHE>/Polypane-28.0.3.dmg
{'Output': {'download_changed': True,
            'pathname': '<CACHE>/Polypane-28.0.3.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '<CACHE>/Polypane-28.0.3.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to <CACHE>/receipts/Polypane.download-receipt-20260403-134514.plist

The following new items were downloaded:
    Download Path
    -------------
    <CACHE>/Polypane-28.0.3.dmg
```

Verified that the downloaded DMG contains a universal binary:

```
$ lipo -archs polypane.app/Contents/MacOS/polypane
x86_64 arm64
```