### PR TITLE
Use pkg for parent of AJA Mini Config munki recipe

### DIFF
--- a/AJA/AJAMiniConfig.munki.recipe
+++ b/AJA/AJAMiniConfig.munki.recipe
@@ -35,14 +35,14 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.homebysix.download.AJAMiniConfig</string>
+	<string>com.github.homebysix.pkg.AJAMiniConfig</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%found_filename%</string>
+				<string>%pkg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
The AJA Mini Config app includes newlines in its version string which breaks Munki version comparison and MunkiImporter filenaming.

Before (notice the versions with newlines):

```
MunkiImporter
{'Input': {'MUNKI_REPO': '~/Developer/cpe-munki-repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.munki.AJAMiniConfig/unzipped/Mini_Config_v2.27.1_macOS/AJA_Mini-Config-2.27.1.108.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The free AJA Mini-Config software '
                                      'allows interactive, visual '
                                      'configuration and complete control of '
                                      'USB-enabled AJA Mini-Converters via a '
                                      'single USB connection to a Mac or PC '
                                      'computer.',
                       'developer': 'AJA',
                       'display_name': 'AJA Mini-Config',
                       'name': 'AJAMiniConfig',
                       'unattended_install': True,
                       'unattended_uninstall': True},
           'repo_subdirectory': 'apps/AJAMiniConfig'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: No value supplied for MUNKI_PKGINFO_FILE_EXTENSION, setting default value of: plist
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: ~/Developer/cpe-munki-repo
MunkiImporter: Copied pkginfo to: ~/Developer/cpe-munki-repo/pkgsinfo/apps/AJAMiniConfig/AJAMiniConfig-2
.27
.1
.108.plist
MunkiImporter:            pkg to: ~/Developer/cpe-munki-repo/pkgs/apps/AJAMiniConfig/AJA_Mini-Config-2.27.1.108-2
.27
.1
.108.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AJAMiniConfig',
                                                       'pkg_repo_path': 'apps/AJAMiniConfig/AJA_Mini-Config-2.27.1.108-2\n'
                                                                        '.27\n'
                                                                        '.1\n'
                                                                        '.108.dmg',
                                                       'pkginfo_path': 'apps/AJAMiniConfig/AJAMiniConfig-2\n'
                                                                       '.27\n'
                                                                       '.1\n'
                                                                       '.108.plist',
                                                       'version': '2\n'
                                                                  '.27\n'
                                                                  '.1\n'
                                                                  '.108'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2026, 4, 7, 23, 6, 45),
                                         'munki_version': '7.1.0.5677',
                                         'os_version': '26.5'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'The free AJA Mini-Config software '
                                          'allows interactive, visual '
                                          'configuration and complete control '
                                          'of USB-enabled AJA Mini-Converters '
                                          'via a single USB connection to a '
                                          'Mac or PC computer.',
                           'developer': 'AJA',
                           'display_name': 'AJA Mini-Config',
                           'installer_item_hash': 'c6c1c9e64ed9ff61a5a76be731ad67bf9554a5af0094c82661d498e5c2adff1c',
                           'installer_item_location': 'apps/AJAMiniConfig/AJA_Mini-Config-2.27.1.108-2\n'
                                                      '.27\n'
                                                      '.1\n'
                                                      '.108.dmg',
                           'installer_item_size': 233148,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.aja.MiniConfig',
                                         'CFBundleName': 'MiniConfig',
                                         'CFBundleShortVersionString': '2\n'
                                                                       '.27\n'
                                                                       '.1\n'
                                                                       '.108',
                                         'CFBundleVersion': '2\n.27\n.1\n.108',
                                         'path': '/Applications/AJA '
                                                 'Mini-Config.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'AJA '
                                                             'Mini-Config.app'}],
                           'name': 'AJAMiniConfig',
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2\n.27\n.1\n.108'},
            'munki_repo_changed': True,
            'pkg_repo_path': '~/Developer/cpe-munki-repo/pkgs/apps/AJAMiniConfig/AJA_Mini-Config-2.27.1.108-2\n'
                             '.27\n'
                             '.1\n'
                             '.108.dmg',
            'pkginfo_repo_path': '~/Developer/cpe-munki-repo/pkgsinfo/apps/AJAMiniConfig/AJAMiniConfig-2\n'
                                 '.27\n'
                                 '.1\n'
                                 '.108.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.munki.AJAMiniConfig/receipts/AJAMiniConfig.munki-receipt-20260407-160645.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.homebysix.munki.AJAMiniConfig/downloads/AJAMiniConfig-2.27.1.zip

The following new items were imported into Munki:
    Name           Version        Catalogs  Pkginfo Path                                          Pkg Repo Path                                                    Icon Repo Path
    ----           -------        --------  ------------                                          -------------                                                    --------------
    AJAMiniConfig  2
.27
.1
.108  testing   apps/AJAMiniConfig/AJAMiniConfig-2
.27
.1
.108.plist  apps/AJAMiniConfig/AJA_Mini-Config-2.27.1.108-2
.27
.1
.108.dmg
```

After (notice the version is now using package receipt with no newlines, not the app version):

```
MunkiImporter
{'Input': {'MUNKI_REPO': '~/Developer/cpe-munki-repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.munki.AJAMiniConfig/AJA '
                       'Mini-Config-2.27.1.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The free AJA Mini-Config software '
                                      'allows interactive, visual '
                                      'configuration and complete control of '
                                      'USB-enabled AJA Mini-Converters via a '
                                      'single USB connection to a Mac or PC '
                                      'computer.',
                       'developer': 'AJA',
                       'display_name': 'AJA Mini-Config',
                       'name': 'AJAMiniConfig',
                       'unattended_install': True,
                       'unattended_uninstall': True},
           'repo_subdirectory': 'apps/AJAMiniConfig'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: No value supplied for MUNKI_PKGINFO_FILE_EXTENSION, setting default value of: plist
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: ~/Developer/cpe-munki-repo
MunkiImporter: Copied pkginfo to: ~/Developer/cpe-munki-repo/pkgsinfo/apps/AJAMiniConfig/AJAMiniConfig-2.27.1.plist
MunkiImporter:            pkg to: ~/Developer/cpe-munki-repo/pkgs/apps/AJAMiniConfig/AJA Mini-Config-2.27.1.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AJAMiniConfig',
                                                       'pkg_repo_path': 'apps/AJAMiniConfig/AJA '
                                                                        'Mini-Config-2.27.1.pkg',
                                                       'pkginfo_path': 'apps/AJAMiniConfig/AJAMiniConfig-2.27.1.plist',
                                                       'version': '2.27.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2026, 4, 7, 23, 8, 45),
                                         'munki_version': '7.1.0.5677',
                                         'os_version': '26.5'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'The free AJA Mini-Config software '
                                          'allows interactive, visual '
                                          'configuration and complete control '
                                          'of USB-enabled AJA Mini-Converters '
                                          'via a single USB connection to a '
                                          'Mac or PC computer.',
                           'developer': 'AJA',
                           'display_name': 'AJA Mini-Config',
                           'installed_size': 312109,
                           'installer_item_hash': '02a2ac6312a345b0a008613aa4d6caf3d387b3c40a986918a66c234c082d4680',
                           'installer_item_location': 'apps/AJAMiniConfig/AJA '
                                                      'Mini-Config-2.27.1.pkg',
                           'installer_item_size': 150049,
                           'name': 'AJAMiniConfig',
                           'receipts': [{'installed_size': 312109,
                                         'packageid': 'com.aja.MiniConfig',
                                         'version': '2.27.1'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '2.27.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '~/Developer/cpe-munki-repo/pkgs/apps/AJAMiniConfig/AJA '
                             'Mini-Config-2.27.1.pkg',
            'pkginfo_repo_path': '~/Developer/cpe-munki-repo/pkgsinfo/apps/AJAMiniConfig/AJAMiniConfig-2.27.1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.munki.AJAMiniConfig/receipts/AJAMiniConfig.munki-receipt-20260407-160845.plist

The following packages were built:
    Identifier          Version  Pkg Path
    ----------          -------  --------
    com.aja.MiniConfig  2.27.1   ~/Library/AutoPkg/Cache/com.github.homebysix.munki.AJAMiniConfig/AJA Mini-Config-2.27.1.pkg

The following new items were imported into Munki:
    Name           Version  Catalogs  Pkginfo Path                                   Pkg Repo Path                                  Icon Repo Path
    ----           -------  --------  ------------                                   -------------                                  --------------
    AJAMiniConfig  2.27.1   testing   apps/AJAMiniConfig/AJAMiniConfig-2.27.1.plist  apps/AJAMiniConfig/AJA Mini-Config-2.27.1.pkg
```
