### PR TITLE
Add ARCH input variable to Browserosaurus download recipe

### DIFF
--- a/Browserosaurus/Browserosaurus.download.recipe
+++ b/Browserosaurus/Browserosaurus.download.recipe
@@ -5,11 +5,20 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Browserosaurus.</string>
+	<string>Downloads the latest version of Browserosaurus.
+
+Use the ARCH input variable to specify the architecture to download.
+Values at the time of writing are:
+
+- arm64 (Apple Silicon, default)
+- x64 (Intel)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Browserosaurus</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>Browserosaurus</string>
 	</dict>
@@ -21,7 +30,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>.*\.zip$</string>
+				<string>Browserosaurus-darwin-%ARCH%-.*\.zip$</string>
 				<key>github_repo</key>
 				<string>will-stone/browserosaurus</string>
 			</dict>


### PR DESCRIPTION
Adds support for downloading either Apple Silicon (arm64) or Intel (x64) builds via the ARCH input variable. Defaults to arm64.

Previously the asset_regex matched both zips indiscriminately.