### PR TITLE
AWSCLI: switch install/pkg recipes to local download parent

### DIFF
--- a/Amazon/AWSCLI.install.recipe
+++ b/Amazon/AWSCLI.install.recipe
@@ -11,7 +11,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.valdore86.download.AWSCLI</string>
+	<string>com.github.homebysix.download.AWSCLI</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Amazon/AWSCLI.pkg.recipe
+++ b/Amazon/AWSCLI.pkg.recipe
@@ -17,7 +17,7 @@ Tags are used since contents of pkg don't have easily parse-able version, probab
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.valdore86.download.AWSCLI</string>
+	<string>com.github.homebysix.download.AWSCLI</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Hi Elliot,

I went and flipped this back to your recipes as the parents it had are now on a deprecation warning.

The `AWSCLI.install.recipe` and `AWSCLI.pkg.recipe` in this folder both reference `com.github.valdore86.download.AWSCLI` as their `ParentRecipe`. The valdore86-recipes repo carries this deprecation notice:

> This recipe is no longer maintained and will be removed after June 2026. Please switch to the maintained replacement: https://github.com/autopkg/homebysix-recipes/tree/master/Amazon

This PR points both child recipes at the local `com.github.homebysix.download.AWSCLI` parent that already lives in this folder, so the Amazon recipes are self-contained and don't depend on a soon-to-be-removed external repo.

## Changes

- `Amazon/AWSCLI.install.recipe` — `ParentRecipe`: `com.github.valdore86.download.AWSCLI` → `com.github.homebysix.download.AWSCLI`
- `Amazon/AWSCLI.pkg.recipe` — same swap

No other changes; the local download recipe already pulls `https://awscli.amazonaws.com/AWSCLIV2.pkg` (AWS CLI v2).

## Test plan

Ran both recipes locally against the updated parent.

### `autopkg run -v Amazon/AWSCLI.download.recipe`

```
autopkg run -v Amazon/AWSCLI.download.recipe
Processing Amazon/AWSCLI.download.recipe...
WARNING: Amazon/AWSCLI.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 30 Apr 2026 19:17:16 GMT
URLDownloader: Storing new ETag header: "72055eb3bc03c4ace00d7ce5e0b3d58f-7"
URLDownloader: Downloaded /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.download.AWSCLI/downloads/AWSCLIV2.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AWSCLIV2.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-04-30 18:31:43 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
CodeSignatureVerifier:        Expires: 2030-09-26 00:18:06 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            5C 45 BE 63 FD 52 10 07 2D 66 56 77 5C A9 FF 25 91 6D 3F 01 F7 0E 
CodeSignatureVerifier:            9A 8A 05 F6 2D 62 B2 88 8D A9
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.download.AWSCLI/receipts/AWSCLI.download-receipt-20260430-135213.plist

The following new items were downloaded:
    Download Path                                                                                             
    -------------                                                                                             
    /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.download.AWSCLI/downloads/AWSCLIV2.pkg 
```

### `autopkg run -v Amazon/AWSCLI.pkg.recipe`

```
autopkg run -v Amazon/AWSCLI.pkg.recipe
Processing Amazon/AWSCLI.pkg.recipe...
WARNING: Amazon/AWSCLI.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 30 Apr 2026 19:17:16 GMT
URLDownloader: Storing new ETag header: "72055eb3bc03c4ace00d7ce5e0b3d58f-7"
URLDownloader: Downloaded /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.pkg.AWSCLI/downloads/AWSCLIV2.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AWSCLIV2.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-04-30 18:31:43 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
CodeSignatureVerifier:        Expires: 2030-09-26 00:18:06 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            5C 45 BE 63 FD 52 10 07 2D 66 56 77 5C A9 FF 25 91 6D 3F 01 F7 0E 
CodeSignatureVerifier:            9A 8A 05 F6 2D 62 B2 88 8D A9
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
URLTextSearcher
URLTextSearcher: Found matching text (version): 2.34.40
PkgCopier
PkgCopier: Copied /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.pkg.AWSCLI/downloads/AWSCLIV2.pkg to /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.pkg.AWSCLI/AWSCLI-2.34.40.pkg
Receipt written to /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.pkg.AWSCLI/receipts/AWSCLI.pkg-receipt-20260430-135348.plist

The following new items were downloaded:
    Download Path                                                                                        
    -------------                                                                                        
    /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.pkg.AWSCLI/downloads/AWSCLIV2.pkg  

The following packages were copied:
    Pkg Path                                                                                         
    --------                                                                                         
    /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.homebysix.pkg.AWSCLI/AWSCLI-2.34.40.pkg  
```
