### PR TITLE
Allow com.emdash identifier in Emdash recipe

### DIFF
--- a/Emdash/Emdash.download.recipe
+++ b/Emdash/Emdash.download.recipe
@@ -45,7 +45,7 @@ Tested values for ARCH include:
 				<key>input_path</key>
 				<string>%pathname%/Emdash.app</string>
 				<key>requirement</key>
-				<string>identifier "com.emdash.stable" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2AZ6648627"</string>
+				<string>(identifier "com.emdash" or identifier "com.emdash.stable") and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2AZ6648627"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This future-proofs the Emdash recipe in case the developer wants to change back to the pre-v1 bundle identifier.