### PR TITLE
Accommodate software titles that fail strict verification

### DIFF
--- a/Applite/Applite.download.recipe
+++ b/Applite/Applite.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Applite.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "dev.aerolite.Applite" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9CLTNBW4Z3")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Apptorium/ScreenFocus.download.recipe
+++ b/Apptorium/ScreenFocus.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/ScreenFocus.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.apptorium.ScreenFocus-dm" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MLZTD8K9AU)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Apptorium/Workspaces.download.recipe
+++ b/Apptorium/Workspaces.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Workspaces.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.apptorium.Workspaces2-paddle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MLZTD8K9AU)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Bookends/Bookends.download.recipe
+++ b/Bookends/Bookends.download.recipe
@@ -39,6 +39,8 @@
 				<string>%pathname%/Bookends.app</string>
 				<key>requirement</key>
 				<string>identifier "com.sonnysoftware.bookends2" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = P9457MD394</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Charm/Charm.download.recipe
+++ b/Charm/Charm.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Charm.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.th.charm" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6FCMW5992Y")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Dockify/Dockify.download.recipe
+++ b/Dockify/Dockify.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Dockify.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.offfwhite.V2.Dockify" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = TZMN75H2RV)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/IrradiatedSoftware/iClip.download.recipe
+++ b/IrradiatedSoftware/iClip.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/iClip.app</string>
 				<key>requirement</key>
 				<string>identifier "com.irradiatedsoftware.iClip" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = GVZ7RF955D</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Lattix/Lattix.download.recipe
+++ b/Lattix/Lattix.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Lattix.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.abjcodes.workspaceX" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PPQ4A2J7RY)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/LaunchOS/LaunchOS.download.recipe
+++ b/LaunchOS/LaunchOS.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/LaunchOS.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "app.remixdesign.LaunchOS" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6BUWDDYC3T")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/MediaHuman/LyricsFinder.download.recipe
+++ b/MediaHuman/LyricsFinder.download.recipe
@@ -41,6 +41,8 @@
 				<string>%pathname%/LyricsFinder.app</string>
 				<key>requirement</key>
 				<string>identifier "com.mediahuman.Lyrics Finder" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3EULEE7KQ5"</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Modoki/Modoki.download.recipe
+++ b/Modoki/Modoki.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Modoki.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.maxoliinyk.modoki" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = F2Z5AUR56U)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/NetViews/NetViews.download.recipe
+++ b/NetViews/NetViews.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/NetViews.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.bmmup.PingStalker" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CTH3T35GRZ)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Open in Atom/Open in Atom.download.recipe
+++ b/Open in Atom/Open in Atom.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Open in Atom.app</string>
 				<key>requirement</key>
 				<string>identifier "com.apple.ScriptEditor.id.Open-in-Atom" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: Christopher Dzombak (JC7TCLR787)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -65,6 +65,8 @@ Input variable tips:
 				<string>%pathname%/Parallels Desktop.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4C6364ACXT")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Perplexity/Comet.download.recipe
+++ b/Perplexity/Comet.download.recipe
@@ -46,6 +46,8 @@ Valid values for ARCH include:
 				<string>%pathname%/Comet.app</string>
 				<key>requirement</key>
 				<string>identifier "ai.perplexity.comet" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7S8W4W365S"</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Postbox/Postbox.download.recipe
+++ b/Postbox/Postbox.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Postbox.app</string>
 				<key>requirement</key>
 				<string>identifier "com.postbox-inc.postbox" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "A9QD7F9VSC"</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/QuickDrawViewer/QuickDrawViewer.download.recipe
+++ b/QuickDrawViewer/QuickDrawViewer.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/QuickDrawViewer.app</string>
 				<key>requirement</key>
 				<string>identifier "net.codiferes.wiesmann.QuickDrawViewer" and anchor apple generic and certificate leaf[subject.CN] = "Apple Development: matthias.wiesmann@a3.epfl.ch (SNV4TDQ3V3)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/SigmaOS/SigmaOS.download.recipe
+++ b/SigmaOS/SigmaOS.download.recipe
@@ -39,6 +39,8 @@
 				<string>%pathname%/SigmaOS.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.sigmaos.sigmaos.macos" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = R4ZAXU7N3C)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Tunabelly/BillBoss.download.recipe
+++ b/Tunabelly/BillBoss.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Bill Boss.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.tunabelly.bills" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9525X5D6XV")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Tunabelly/DiskDiet.download.recipe
+++ b/Tunabelly/DiskDiet.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/Disk Diet.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.tunabellysoftware.diskdiet" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9525X5D6XV")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Tunabelly/FolderTidy.download.recipe
+++ b/Tunabelly/FolderTidy.download.recipe
@@ -61,6 +61,8 @@
 				<string>%pathname%/Folder Tidy.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.tunabellysoftware.cleanmydesktop" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9525X5D6XV")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Tunabelly/TGPro.download.recipe
+++ b/Tunabelly/TGPro.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/TG Pro.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.tunabellysoftware.tgpro" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9525X5D6XV")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/UnGoogledChromium/UnGoogledChromium.download.recipe
+++ b/UnGoogledChromium/UnGoogledChromium.download.recipe
@@ -55,6 +55,8 @@ Tested values for ARCH include:
 				<string>%pathname%/Chromium.app</string>
 				<key>requirement</key>
 				<string>identifier "io.ungoogled-software.ungoogled-chromium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/WindowKeys/WindowKeys.download.recipe
+++ b/WindowKeys/WindowKeys.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/WindowKeys.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.apptorium.WindowKeys" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MLZTD8K9AU)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Wins/Wins.download.recipe
+++ b/Wins/Wins.download.recipe
@@ -59,6 +59,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Wins.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "cools.wins.main" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = NR9F93G9FY)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/ZenBrowser/Zen.download.recipe
+++ b/ZenBrowser/Zen.download.recipe
@@ -48,6 +48,8 @@
 				<string>%pathname%/Zen.app</string>
 				<key>requirement</key>
 				<string>identifier "app.zen-browser.zen" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9V5K9TP787"</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/macUSB/macUSB.download.recipe
+++ b/macUSB/macUSB.download.recipe
@@ -46,6 +46,8 @@
 				<string>%pathname%/macUSB.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.kruszoneq.macUSB" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "27NC66L8P2")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This PR adds `strict_verification: false` to the `CodeSignatureVerifier` step(s) in one or more of your download recipes.

The next version of AutoPkg will likely change `CodeSignatureVerifier` so that `strict_verification` defaults to true instead of false. Under strict verification, `codesign --strict` rejects apps with specific build anomalies (e.g. `com.apple.FinderInfo`, resource forks) — which currently affect recipes in this repo.

Setting `strict_verification: false` explicitly opts these recipes out of that upcoming default so they keep working after the release. Because `false` is also the *current* default, this change is safe to merge. The recipe is simply being pinned to its existing verification behavior.

To confirm the change works, a comment on this PR includes the verbatim `autopkg run -vv` output showing the recipe still verifies successfully with the change applied.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.