### PR TITLE
Use SparkleUpdateInfoProvider's urlencode_path_component instead of FindAndReplace double-encoding workaround

### DIFF
--- a/Arie van Boxel/StartupManagerPro.download.recipe
+++ b/Arie van Boxel/StartupManagerPro.download.recipe
@@ -22,6 +22,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://startupmanager.appmac.fr/update/sparkle/appcast.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -29,21 +31,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Bartender/Bartender.download.recipe
+++ b/Bartender/Bartender.download.recipe
@@ -22,7 +22,7 @@ the appropriate team identifier for previous versions.
 		<string>24J875RH8J</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.3</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -30,6 +30,8 @@ the appropriate team identifier for previous versions.
 			<dict>
 				<key>appcast_url</key>
 				<string>https://www.macbartender.com/B2/updates/AppcastB%MAJOR_VERSION%.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -37,23 +39,10 @@ the appropriate team identifier for previous versions.
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.zip</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/RocketTypist/RocketTypist.download.recipe
+++ b/RocketTypist/RocketTypist.download.recipe
@@ -22,6 +22,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://www.witt-software.com/downloads/rockettypist/appcast.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -29,25 +31,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Comment</key>
-			<string>The Sparkle feed contains a double-encoded download URL, so we must manually fix it here.</string>
-			<key>Processor</key>
-			<string>FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Screens/Screens.download.recipe
+++ b/Screens/Screens.download.recipe
@@ -14,7 +14,7 @@
 		<string>Screens</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -22,6 +22,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://updates.edovia.com/com.edovia.screens4.mac/appcast.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -29,25 +31,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Comment</key>
-			<string>The Screens Sparkle feed contains a double-encoded download URL, so we must manually fix it here.</string>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.zip</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Sidebar/Sidebar.download.recipe
+++ b/Sidebar/Sidebar.download.recipe
@@ -22,26 +22,11 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://download.sidebarapp.net/appcast.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-				<key>result_output_var_name</key>
-				<string>url</string>
-			</dict>
-			<key>Comment</key>
-			<string>The Sparkle feed contains a double-encoded download URL, so we must manually fix the spaces here.</string>
-			<key>Processor</key>
-			<string>FindAndReplace</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>

--- a/Tunabelly/FolderTidy.download.recipe
+++ b/Tunabelly/FolderTidy.download.recipe
@@ -12,7 +12,7 @@
 		<string>Folder Tidy</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -20,6 +20,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://www.tunabellysoftware.com/resources/sparkle/foldertidy.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -27,25 +29,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Comment</key>
-			<string>The Folder Tidy Sparkle feed contains a double-encoded download URL, so we must manually fix the spaces here.</string>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Tunabelly/QRFactory.download.recipe
+++ b/Tunabelly/QRFactory.download.recipe
@@ -14,7 +14,7 @@
 		<string>QR Factory</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -22,6 +22,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://tunabellysoftware.com/resources/sparkle/qrfactory.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -29,25 +31,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Comment</key>
-			<string>The QR Factory Sparkle feed contains a double-encoded download URL, so we must manually fix the spaces here.</string>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Unfolder/Unfolder.download.recipe
+++ b/Unfolder/Unfolder.download.recipe
@@ -22,6 +22,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://www.unfolder.app/appcast.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -29,23 +31,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/iManage/iManageWorkDesktop.download.recipe
+++ b/iManage/iManageWorkDesktop.download.recipe
@@ -14,7 +14,7 @@
 		<string>iManageWorkDesktop</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -22,6 +22,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>https://updates.imanage.com/autoupdates/appcast.xml</string>
+				<key>urlencode_path_component</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -29,25 +31,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>find</key>
-				<string>%2520</string>
-				<key>input_string</key>
-				<string>%url%</string>
-				<key>replace</key>
-				<string>%20</string>
-			</dict>
-			<key>Comment</key>
-			<string>The Sparkle feed contains a double-encoded download URL, so we must manually fix it here.</string>
-			<key>Processor</key>
-			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%-%version%.zip</string>
 				<key>url</key>
-				<string>%output_string%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION

When a Sparkle feed already contains a percent-encoded URL (e.g. `%20` for a space in the filename), `SparkleUpdateInfoProvider` re-encodes it by default — turning `%20` into `%2520`. The `FindAndReplace` step was a workaround to undo that.

`SparkleUpdateInfoProvider` has supported the `urlencode_path_component` input variable since AutoPkg 1.1. Setting it to `false` tells the processor to leave the URL path as-is, so the double-encoding never occurs and the workaround becomes unnecessary.

This PR removes the `FindAndReplace` workaround from one or more of your download recipes.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.

## Verbose output

This shows the `autopkg run -vv` output for your recipe(s) after the change:

```
WARNING: Screens/Screens.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Screens/Screens.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://updates.edovia.com/com.edovia.screens4.mac/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 39
SparkleUpdateInfoProvider: Items in default channel: 39
SparkleUpdateInfoProvider: Version retrieved from appcast: 1696599453
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.12.16
SparkleUpdateInfoProvider: Found URL https://updates.edovia.com/com.edovia.screens4.mac/Screens_4.12.16b1696599453.zip
{'Output': {'url': 'https://updates.edovia.com/com.edovia.screens4.mac/Screens_4.12.16b1696599453.zip',
            'version': '4.12.16'}}
URLDownloader
{'Input': {'filename': 'Screens-4.12.16.zip',
           'url': 'https://updates.edovia.com/com.edovia.screens4.mac/Screens_4.12.16b1696599453.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://updates.edovia.com/com.edovia.screens4.mac/Screens_4.12.16b1696599453.zip', 'file_name': 'Screens-4.12.16.zip', 'file_size': 22832146, 'http_headers': {'Content-Length': 22832146, 'ETag': '"15c6412-6070c64f51e07"', 'Last-Modified': 'Fri, 06 Oct 2023 13:41:15 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/downloads/Screens-4.12.16.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/downloads/Screens-4.12.16.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/downloads/Screens-4.12.16.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/Screens/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Screens-4.12.16.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/downloads/Screens-4.12.16.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/Screens/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/Screens/Applications/Screens '
                         '4.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.edovia.screens4.mac" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = F69M46B76S)'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/Screens/Applications/Screens 4.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/Screens/Applications/Screens 4.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/Screens/Applications/Screens 4.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Screens/receipts/Screens.download-receipt-20260620-192023.plist

Nothing downloaded, packaged or imported.


WARNING: Bartender/Bartender.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Bartender/Bartender.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.macbartender.com/B2/updates/AppcastB6.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 14
SparkleUpdateInfoProvider: Items in default channel: 14
SparkleUpdateInfoProvider: Version retrieved from appcast: 652000
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 6.5.2
SparkleUpdateInfoProvider: Found URL https://downloads.macbartender.com/B2/updates/6-5-2/Bartender%206.zip
{'Output': {'url': 'https://downloads.macbartender.com/B2/updates/6-5-2/Bartender%206.zip',
            'version': '6.5.2'}}
URLDownloader
{'Input': {'filename': 'Bartender-6.5.2.zip',
           'url': 'https://downloads.macbartender.com/B2/updates/6-5-2/Bartender%206.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://downloads.macbartender.com/B2/updates/6-5-2/Bartender%206.zip', 'file_name': 'Bartender-6.5.2.zip', 'file_size': 54043401, 'http_headers': {'Content-Length': 54043401, 'ETag': '"38532521221710846fa13a388222858e"', 'Last-Modified': 'Fri, 22 May 2026 16:17:35 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/downloads/Bartender-6.5.2.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/downloads/Bartender-6.5.2.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/downloads/Bartender-6.5.2.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/Bartender',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Bartender-6.5.2.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/downloads/Bartender-6.5.2.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/Bartender
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/Bartender/Bartender '
                         '6.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.surteesstudios.Bartender" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "24J875RH8J")'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/Bartender/Bartender 6.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/Bartender/Bartender 6.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/Bartender/Bartender 6.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Bartender/receipts/Bartender.download-receipt-20260620-192028.plist

Nothing downloaded, packaged or imported.


WARNING: iManage/iManageWorkDesktop.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing iManage/iManageWorkDesktop.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://updates.imanage.com/autoupdates/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 108441
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 10.8.4
SparkleUpdateInfoProvider: Found URL https://updates.imanage.com/autoupdates/iManage%20Work%20Desktop%20for%20Mac.pkg.zip
{'Output': {'url': 'https://updates.imanage.com/autoupdates/iManage%20Work%20Desktop%20for%20Mac.pkg.zip',
            'version': '10.8.4'}}
URLDownloader
{'Input': {'filename': 'iManageWorkDesktop-10.8.4.zip',
           'url': 'https://updates.imanage.com/autoupdates/iManage%20Work%20Desktop%20for%20Mac.pkg.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://updates.imanage.com/autoupdates/iManage%20Work%20Desktop%20for%20Mac.pkg.zip', 'file_name': 'iManageWorkDesktop-10.8.4.zip', 'file_size': 172028911, 'http_headers': {'Content-Length': 172028911, 'ETag': '"1f4dc1d62948dc1:0"', 'Last-Modified': 'Tue, 28 Oct 2025 16:42:24 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/downloads/iManageWorkDesktop-10.8.4.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/downloads/iManageWorkDesktop-10.8.4.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/downloads/iManageWorkDesktop-10.8.4.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/iManageWorkDesktop',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename iManageWorkDesktop-10.8.4.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/downloads/iManageWorkDesktop-10.8.4.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/iManageWorkDesktop
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: iManage LLC '
                                        '(HGLC38RWEJ)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/iManageWorkDesktop/iManage '
                         'Work Desktop for Mac.sparkle_interactive.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "iManage Work Desktop for Mac.sparkle_interactive.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-10-23 10:16:44 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: iManage LLC (HGLC38RWEJ)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            A5 7E E7 90 3D A4 06 69 6F 78 59 58 30 80 77 B3 70 DC 6C 2A 3B 9D 
CodeSignatureVerifier:            7C E1 70 8E 86 95 4D 19 DE 8D
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.iManageWorkDesktop/receipts/iManageWorkDesktop.download-receipt-20260620-192356.plist

Nothing downloaded, packaged or imported.


WARNING: RocketTypist/RocketTypist.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing RocketTypist/RocketTypist.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.witt-software.com/downloads/rockettypist/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 43
SparkleUpdateInfoProvider: Items in default channel: 43
SparkleUpdateInfoProvider: Version retrieved from appcast: 438
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.3.1
SparkleUpdateInfoProvider: Found URL https://witt-software.com/downloads/rockettypist/Rocket%20Typist.dmg
{'Output': {'url': 'https://witt-software.com/downloads/rockettypist/Rocket%20Typist.dmg',
            'version': '3.3.1'}}
URLDownloader
{'Input': {'filename': 'Rocket Typist-3.3.1.dmg',
           'url': 'https://witt-software.com/downloads/rockettypist/Rocket%20Typist.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://witt-software.com/downloads/rockettypist/Rocket%20Typist.dmg', 'file_name': 'Rocket Typist-3.3.1.dmg', 'file_size': 20633951, 'http_headers': {'Content-Length': 20633951, 'ETag': '"13ad95f-64b6e7558b234"', 'Last-Modified': 'Sun, 22 Feb 2026 19:14:07 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.RocketTypist/downloads/Rocket Typist-3.3.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.RocketTypist/downloads/Rocket '
                        'Typist-3.3.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.RocketTypist/downloads/Rocket '
                         'Typist-3.3.1.dmg/Rocket Typist.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.witt-software.Rocket-Typist-2" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'GH2Y99U35Z)'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.RocketTypist/downloads/Rocket Typist-3.3.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.4utw1K/Rocket Typist.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.4utw1K/Rocket Typist.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.4utw1K/Rocket Typist.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.RocketTypist/receipts/RocketTypist.download-receipt-20260620-192409.plist

Nothing downloaded, packaged or imported.


WARNING: Sidebar/Sidebar.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Sidebar/Sidebar.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://download.sidebarapp.net/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 5
SparkleUpdateInfoProvider: Items in default channel: 5
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.0.9
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.0.9
SparkleUpdateInfoProvider: Found URL https://download.sidebarapp.net/Sidebar%202.0.9.dmg
{'Output': {'url': 'https://download.sidebarapp.net/Sidebar%202.0.9.dmg',
            'version': '2.0.9'}}
URLDownloader
{'Input': {'filename': 'Sidebar-2.0.9.dmg',
           'url': 'https://download.sidebarapp.net/Sidebar%202.0.9.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://download.sidebarapp.net/Sidebar%202.0.9.dmg', 'file_name': 'Sidebar-2.0.9.dmg', 'file_size': 20358961, 'http_headers': {'Content-Length': 20358961, 'ETag': '"6a2fb84e-136a731"', 'Last-Modified': 'Mon, 15 Jun 2026 08:31:10 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.Sidebar/downloads/Sidebar-2.0.9.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Sidebar/downloads/Sidebar-2.0.9.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Sidebar/downloads/Sidebar-2.0.9.dmg/Sidebar.app',
           'requirement': 'anchor apple generic and identifier '
                          '"at.sidebar.Sidebar" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = JJR92LZTDM)'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.Sidebar/downloads/Sidebar-2.0.9.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.SDGpZ5/Sidebar.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SDGpZ5/Sidebar.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SDGpZ5/Sidebar.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Sidebar/receipts/Sidebar.download-receipt-20260620-192427.plist

Nothing downloaded, packaged or imported.


WARNING: Arie van Boxel/StartupManagerPro.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Arie van Boxel/StartupManagerPro.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://startupmanager.appmac.fr/update/sparkle/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 6
SparkleUpdateInfoProvider: Items in default channel: 6
SparkleUpdateInfoProvider: Version retrieved from appcast: 79
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.1.4
SparkleUpdateInfoProvider: Found URL https://startupmanager.appmac.fr/update/sparkle/Startup%20Manager%20Pro-2.1.4.dmg
{'Output': {'url': 'https://startupmanager.appmac.fr/update/sparkle/Startup%20Manager%20Pro-2.1.4.dmg',
            'version': '2.1.4'}}
URLDownloader
{'Input': {'url': 'https://startupmanager.appmac.fr/update/sparkle/Startup%20Manager%20Pro-2.1.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://startupmanager.appmac.fr/update/sparkle/Startup%20Manager%20Pro-2.1.4.dmg', 'file_name': 'Startup%20Manager%20Pro-2.1.4.dmg', 'file_size': 3992283, 'http_headers': {'Content-Length': 3992283, 'ETag': '', 'Last-Modified': 'Sat, 13 Jun 2026 06:08:46 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.StartupManagerPro/downloads/Startup%20Manager%20Pro-2.1.4.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.StartupManagerPro/downloads/Startup%20Manager%20Pro-2.1.4.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.StartupManagerPro/downloads/Startup%20Manager%20Pro-2.1.4.dmg/Startup '
                         'Manager Pro.app',
           'requirement': 'anchor apple generic and identifier '
                          '"fr.arievanboxel.startupmanagerpro" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"488UD3H8PZ")'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.StartupManagerPro/downloads/Startup%20Manager%20Pro-2.1.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.DM8Esc/Startup Manager Pro.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.DM8Esc/Startup Manager Pro.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.DM8Esc/Startup Manager Pro.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.StartupManagerPro/receipts/StartupManagerPro.download-receipt-20260620-192436.plist

Nothing downloaded, packaged or imported.


WARNING: Unfolder/Unfolder.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Unfolder/Unfolder.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.unfolder.app/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 221
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.1.0
SparkleUpdateInfoProvider: Found URL https://www.unfolder.app/Unfolder%202.1.0.dmg
{'Output': {'url': 'https://www.unfolder.app/Unfolder%202.1.0.dmg',
            'version': '2.1.0'}}
URLDownloader
{'Input': {'filename': 'Unfolder-2.1.0.dmg',
           'url': 'https://www.unfolder.app/Unfolder%202.1.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://www.unfolder.app/Unfolder%202.1.0.dmg', 'file_name': 'Unfolder-2.1.0.dmg', 'file_size': 11458428, 'http_headers': {'Content-Length': 11458428, 'ETag': '"10a090a49214691eb3e3946894211736"', 'Last-Modified': ''}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.Unfolder/downloads/Unfolder-2.1.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Unfolder/downloads/Unfolder-2.1.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Unfolder/downloads/Unfolder-2.1.0.dmg/Unfolder.app',
           'requirement': 'anchor apple generic and identifier '
                          '"app.unfolder.UnfolderL" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = CKZYLR493P)'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.Unfolder/downloads/Unfolder-2.1.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.H80QRO/Unfolder.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.H80QRO/Unfolder.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.H80QRO/Unfolder.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Unfolder/receipts/Unfolder.download-receipt-20260620-192442.plist

Nothing downloaded, packaged or imported.


WARNING: Tunabelly/FolderTidy.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Tunabelly/FolderTidy.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.tunabellysoftware.com/resources/sparkle/foldertidy.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 4
SparkleUpdateInfoProvider: Items in default channel: 4
SparkleUpdateInfoProvider: Version retrieved from appcast: 3130
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.9.7
SparkleUpdateInfoProvider: Found URL https://www.tunabellysoftware.com/resources/Folder%20Tidy%202.9.7.dmg
{'Output': {'url': 'https://www.tunabellysoftware.com/resources/Folder%20Tidy%202.9.7.dmg',
            'version': '2.9.7'}}
URLDownloader
{'Input': {'filename': 'Folder Tidy-2.9.7.dmg',
           'url': 'https://www.tunabellysoftware.com/resources/Folder%20Tidy%202.9.7.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://www.tunabellysoftware.com/resources/Folder%20Tidy%202.9.7.dmg', 'file_name': 'Folder Tidy-2.9.7.dmg', 'file_size': 6041932, 'http_headers': {'Content-Length': 6041932, 'ETag': '"5c314c-650024ee32cc7"', 'Last-Modified': 'Wed, 22 Apr 2026 01:18:23 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.FolderTidy/downloads/Folder Tidy-2.9.7.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.FolderTidy/downloads/Folder '
                        'Tidy-2.9.7.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.FolderTidy/downloads/Folder '
                         'Tidy-2.9.7.dmg/Folder Tidy.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.tunabellysoftware.cleanmydesktop" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"9525X5D6XV")',
           'strict_verification': False}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.FolderTidy/downloads/Folder Tidy-2.9.7.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /private/tmp/dmg.NFZbXl/Folder Tidy.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.NFZbXl/Folder Tidy.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.NFZbXl/Folder Tidy.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.FolderTidy/receipts/FolderTidy.download-receipt-20260620-192446.plist

Nothing downloaded, packaged or imported.


WARNING: Tunabelly/QRFactory.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Tunabelly/QRFactory.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://tunabellysoftware.com/resources/sparkle/qrfactory.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 1220
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.9.17
SparkleUpdateInfoProvider: Found URL https://www.tunabellysoftware.com/resources/QR%20Factory%202.9.17.dmg
{'Output': {'url': 'https://www.tunabellysoftware.com/resources/QR%20Factory%202.9.17.dmg',
            'version': '2.9.17'}}
URLDownloader
{'Input': {'filename': 'QR Factory-2.9.17.dmg',
           'url': 'https://www.tunabellysoftware.com/resources/QR%20Factory%202.9.17.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://www.tunabellysoftware.com/resources/QR%20Factory%202.9.17.dmg', 'file_name': 'QR Factory-2.9.17.dmg', 'file_size': 11169157, 'http_headers': {'Content-Length': 11169157, 'ETag': '"aa6d85-5a2e168413b00"', 'Last-Modified': 'Thu, 09 Apr 2020 20:24:44 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.QRFactory/downloads/QR Factory-2.9.17.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.QRFactory/downloads/QR '
                        'Factory-2.9.17.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.QRFactory/downloads/QR '
                         'Factory-2.9.17.dmg/QR Factory.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.tunabellysoftware.qrfactory" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "9525X5D6XV")'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.QRFactory/downloads/QR Factory-2.9.17.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.M7GUc1/QR Factory.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.M7GUc1/QR Factory.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.M7GUc1/QR Factory.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.QRFactory/receipts/QRFactory.download-receipt-20260620-192451.plist

Nothing downloaded, packaged or imported.


```
