### PR TITLE
Update Codex recipes for ChatGPT app rename

### DIFF
--- a/OpenAI/Codex.download.recipe
+++ b/OpenAI/Codex.download.recipe
@@ -23,7 +23,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://persistent.oaistatic.com/codex-app-prod/Codex.dmg</string>
+				<string>https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/OpenAI/Codex.download.recipe
+++ b/OpenAI/Codex.download.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.5.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Codex.</string>
+	<string>Downloads the latest version of ChatGPT (formerly Codex).</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Codex</string>
 	<key>Input</key>
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Codex.app</string>
+				<string>%pathname%/ChatGPT.app</string>
 				<key>requirement</key>
 				<string>identifier "com.openai.codex" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2DC432GLL2"</string>
 			</dict>
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Codex.app/Contents/Info.plist</string>
+				<string>%pathname%/ChatGPT.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/OpenAI/Codex.install.recipe
+++ b/OpenAI/Codex.install.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.5.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Installs the latest version of Codex.</string>
+	<string>Installs the latest version of ChatGPT (formerly Codex).</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.install.Codex</string>
 	<key>Input</key>
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>Codex.app</string>
+						<string>ChatGPT.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/OpenAI/Codex.munki.recipe
+++ b/OpenAI/Codex.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.5.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Codex and imports it into Munki.</string>
+	<string>Downloads the latest version of ChatGPT (formerly Codex) and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.munki.Codex</string>
 	<key>Input</key>
@@ -25,7 +25,7 @@
 			<key>developer</key>
 			<string>OpenAI</string>
 			<key>display_name</key>
-			<string>Codex</string>
+			<string>ChatGPT</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>

--- a/OpenAI/Codex.pkg.recipe
+++ b/OpenAI/Codex.pkg.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.5.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Codex and creates a package.</string>
+	<string>Downloads the latest version of ChatGPT (formerly Codex) and creates a package.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.pkg.Codex</string>
 	<key>Input</key>


### PR DESCRIPTION
## Summary

- update Codex recipes for the current DMG contents, where the app bundle is now `ChatGPT.app`
- keep the existing Codex recipe identifiers and cache naming stable
- update install source item and Munki display name for the renamed app

## Verification

- `plutil -lint OpenAI/Codex.download.recipe OpenAI/Codex.install.recipe OpenAI/Codex.munki.recipe OpenAI/Codex.pkg.recipe`
- `autopkg audit OpenAI/Codex.download.recipe`
- `autopkg audit OpenAI/Codex.install.recipe`
- `autopkg audit OpenAI/Codex.munki.recipe`
- `autopkg audit OpenAI/Codex.pkg.recipe`
- `autopkg run OpenAI/Codex.download.recipe -p <path-to-downloaded-Codex.dmg> ...`
- `autopkg run OpenAI/Codex.pkg.recipe -p <path-to-downloaded-Codex.dmg> ...`
- `autopkg run OpenAI/Codex.munki.recipe -p <path-to-downloaded-Codex.dmg> -k MUNKI_REPO=<path-to-test-munki-repo> ...`

The download recipe successfully verified `ChatGPT.app` against the existing `com.openai.codex` requirement and found version `26.707.31428`.
The pkg recipe built `ChatGPT-26.707.31428.pkg`, and the Munki recipe imported `Codex-26.707.31428.dmg` into a test Munki repo with `source_item` set to `ChatGPT.app`.
