### PR TITLE
scrollsnap: use FileFinder for dynamic app path resolution

### DIFF
--- a/ScrollSnap/ScrollSnap.download.recipe
+++ b/ScrollSnap/ScrollSnap.download.recipe
@@ -66,8 +66,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ScrollSnap*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/ScrollSnap %version%.app/Contents/Info.plist</string>
+				<string>%found_filename%/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Replace the hardcoded versioned app bundle path with a FileFinder step, since the unpacked app is named ScrollSnap 3.app rather than ScrollSnap <version>.app.