### PR TITLE
Cleanup GitHub Desktop temp directories

### DIFF
--- a/GitHub/GitHubDesktop.munki.recipe
+++ b/GitHub/GitHubDesktop.munki.recipe
@@ -97,6 +97,17 @@ exit 0
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/GitHub/GitHubDesktop.pkg.recipe
+++ b/GitHub/GitHubDesktop.pkg.recipe
@@ -50,6 +50,17 @@
 			<key>Processor</key>
 			<string>PkgCreator</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR cleans up the temporary **GitHub Desktop** directory when running the following recipes:

- `GitHubDesktop.pkg.recipe`
- `GitHubDesktop.munki.recipe`

Should save `~700MB` of disk space per recipe :broom: