### PR TITLE
Handy architecture support

### DIFF
--- a/Handy/Handy.download.recipe
+++ b/Handy/Handy.download.recipe
@@ -6,29 +6,54 @@
 	<string>Created with Recipe Robot v2.5.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Handy.
-
-Tested values for ARCH include:
-- x64 (default, Intel)
-- aarch64 (Apple Silicon)
-</string>
+		Set ARCH to either:
+		- arm64 (default, Apple Silicon)
+		- x86_64 (Intel)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.Handy</string>
 	<key>Input</key>
 	<dict>
 		<key>ARCH</key>
-		<string>x64</string>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>Handy</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>2.3</string>
+	<string>2.9</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>input_string</key>
+				<string>%ARCH%</string>
+				<key>find</key>
+				<string>arm64</string>
+				<key>replace</key>
+				<string>aarch64</string>
+			</dict>
+			<key>Processor</key>
+			<string>FindAndReplace</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_string</key>
+				<string>%output_string%</string>
+				<key>find</key>
+				<string>x86_64</string>
+				<key>replace</key>
+				<string>x64</string>
+			</dict>
+			<key>Processor</key>
+			<string>FindAndReplace</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>asset_regex</key>
-				<string>.*_%ARCH%\.dmg$</string>
+				<string>.*_%output_string%\.dmg$</string>
 				<key>github_repo</key>
 				<string>cjpais/Handy</string>
 			</dict>
@@ -36,6 +61,11 @@ Tested values for ARCH include:
 			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%ARCH%-%version%.dmg</string>
+			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>

--- a/Handy/Handy.download.recipe
+++ b/Handy/Handy.download.recipe
@@ -26,10 +26,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_string</key>
-				<string>%ARCH%</string>
 				<key>find</key>
 				<string>arm64</string>
+				<key>input_string</key>
+				<string>%ARCH%</string>
 				<key>replace</key>
 				<string>aarch64</string>
 			</dict>
@@ -39,10 +39,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_string</key>
-				<string>%output_string%</string>
 				<key>find</key>
 				<string>x86_64</string>
+				<key>input_string</key>
+				<string>%output_string%</string>
 				<key>replace</key>
 				<string>x64</string>
 			</dict>

--- a/Handy/Handy.munki.recipe
+++ b/Handy/Handy.munki.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
+		<string>apps/%NAME%/%ARCH%</string>
 		<key>NAME</key>
 		<string>Handy</string>
 		<key>pkginfo</key>
@@ -28,6 +28,10 @@
 			<string>Handy</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>


### PR DESCRIPTION
- Adds FindAndReplace so a single `ARCH` value can be used for both the download and the Munki `supported_architectures` array.
- Flips the default to `arm64`

[Handy-arm64.txt](https://github.com/user-attachments/files/31035410/Handy-arm64.txt)
[Handy-x86_64.txt](https://github.com/user-attachments/files/31035412/Handy-x86_64.txt)
