### PR TITLE
Remove redundant version from item filenames

### DIFF
--- a/Apfel/apfel-gui.pkg.recipe
+++ b/Apfel/apfel-gui.pkg.recipe
@@ -95,7 +95,7 @@
 					<key>id</key>
 					<string>com.github.arthur-ficial.apfel-gui</string>
 					<key>pkgname</key>
-					<string>apfel-gui-%version%-%ARCH%</string>
+					<string>apfel-gui-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/Apfel/apfel.pkg.recipe
+++ b/Apfel/apfel.pkg.recipe
@@ -97,7 +97,7 @@
 					<key>id</key>
 					<string>com.github.arthur-ficial.apfel</string>
 					<key>pkgname</key>
-					<string>apfel-%version%-%ARCH%</string>
+					<string>apfel-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/Cartero/Cartero.download.recipe
+++ b/Cartero/Cartero.download.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/ClipBook/ClipBook.download.recipe
+++ b/ClipBook/ClipBook.download.recipe
@@ -41,7 +41,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 				<key>url</key>
 				<string>https://f005.backblazeb2.com/%filepath%</string>
 			</dict>

--- a/Cursr/Cursr.download.recipe
+++ b/Cursr/Cursr.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Deltopia/DeltaWalker.download.recipe
+++ b/Deltopia/DeltaWalker.download.recipe
@@ -39,7 +39,7 @@ Valid values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/DesktopCommander/DesktopCommander.download.recipe
+++ b/DesktopCommander/DesktopCommander.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Eagle/Eagle.download.recipe
+++ b/Eagle/Eagle.download.recipe
@@ -41,7 +41,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Freelens/Freelens.download.recipe
+++ b/Freelens/Freelens.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.pkg</string>
+				<string>%NAME%-%ARCH%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/JetBrains/JetBrainsAir.download.recipe
+++ b/JetBrains/JetBrainsAir.download.recipe
@@ -37,7 +37,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Kando/Kando.download.recipe
+++ b/Kando/Kando.download.recipe
@@ -39,7 +39,7 @@ Tested values of ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Lumen/Lumen.download.recipe
+++ b/Lumen/Lumen.download.recipe
@@ -41,7 +41,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 				<key>url</key>
 				<string>https://lumentodo.com/dl/Lumen-%version%-%ARCH%.dmg</string>
 			</dict>

--- a/Nimbalyst/Nimbalyst.download.recipe
+++ b/Nimbalyst/Nimbalyst.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Peergos/Peergos.download.recipe
+++ b/Peergos/Peergos.download.recipe
@@ -41,7 +41,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.pkg</string>
+				<string>%NAME%-%ARCH%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Rowboat/Rowboat.download.recipe
+++ b/Rowboat/Rowboat.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Vibeyard/Vibeyard.download.recipe
+++ b/Vibeyard/Vibeyard.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%%ARCH%.dmg</string>
+				<string>%NAME%%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Yorishiro/Yorishiro.download.recipe
+++ b/Yorishiro/Yorishiro.download.recipe
@@ -39,7 +39,7 @@ Tested values for ARCH include:
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/agent-of-empires/agent-of-empires.pkg.recipe
+++ b/agent-of-empires/agent-of-empires.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>com.github.njbrake.agentofempires</string>
 					<key>pkgname</key>
-					<string>agent-of-empires-%version%-%ARCH%</string>
+					<string>agent-of-empires-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/chloe/chloe.pkg.recipe
+++ b/chloe/chloe.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>com.github.kevinedry.chloe</string>
 					<key>pkgname</key>
-					<string>chloe-%version%-%ARCH%</string>
+					<string>chloe-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/claude-squad/claude-squad.pkg.recipe
+++ b/claude-squad/claude-squad.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>ai.smtg.claudesquad</string>
 					<key>pkgname</key>
-					<string>claude-squad-%version%-%ARCH%</string>
+					<string>claude-squad-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/continue-cli/continue-cli.pkg.recipe
+++ b/continue-cli/continue-cli.pkg.recipe
@@ -60,7 +60,7 @@
 					<key>id</key>
 					<string>com.github.continuedev.continuecli</string>
 					<key>pkgname</key>
-					<string>continue-cli-%version%-%ARCH%</string>
+					<string>continue-cli-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/draw.io/draw.io.download.recipe
+++ b/draw.io/draw.io.download.recipe
@@ -30,7 +30,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-universal.dmg</string>
+				<string>%NAME%-universal.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/imput/HeliumBrowser.download.recipe
+++ b/imput/HeliumBrowser.download.recipe
@@ -34,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-%ARCH%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/jq/jq.pkg.recipe
+++ b/jq/jq.pkg.recipe
@@ -71,7 +71,7 @@
 					<key>id</key>
 					<string>%PKG_ID%</string>
 					<key>pkgname</key>
-					<string>%NAME%-%version%-%ARCH%</string>
+					<string>%NAME%-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 					<key>version</key>

--- a/purple/purple.pkg.recipe
+++ b/purple/purple.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>com.github.erickochen.purple</string>
 					<key>pkgname</key>
-					<string>purple-%version%-%ARCH%</string>
+					<string>purple-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/quien/quien.pkg.recipe
+++ b/quien/quien.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>com.github.retlehs.quien</string>
 					<key>pkgname</key>
-					<string>quien-%version%-%ARCH%</string>
+					<string>quien-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/sheets/sheets.pkg.recipe
+++ b/sheets/sheets.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>com.github.maaslalani.sheets</string>
 					<key>pkgname</key>
-					<string>sheets-%version%-%ARCH%</string>
+					<string>sheets-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/syntaqlite/syntaqlite.pkg.recipe
+++ b/syntaqlite/syntaqlite.pkg.recipe
@@ -80,7 +80,7 @@
 					<key>id</key>
 					<string>com.github.LalitMaganti.syntaqlite</string>
 					<key>pkgname</key>
-					<string>syntaqlite-%version%-%ARCH%</string>
+					<string>syntaqlite-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>

--- a/workmux/workmux.pkg.recipe
+++ b/workmux/workmux.pkg.recipe
@@ -73,7 +73,7 @@
 					<key>id</key>
 					<string>com.github.raine.workmux</string>
 					<key>pkgname</key>
-					<string>workmux-%version%-%ARCH%</string>
+					<string>workmux-%ARCH%</string>
 					<key>pkgroot</key>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<key>version</key>


### PR DESCRIPTION
`MunkiImporter` appends the version to the installer item name unless the name already ends with it, so recipes with the version in the middle have been importing as `Foo-1.2.3-arm64-1.2.3.pkg`. Dropping `%version%` from `pkgname` lets the import add it once, giving `Foo-arm64-1.2.3.pkg`. Same fix on the download `filename` for the recipes whose munki recipe imports `%pathname%` directly.

Cosmetic only, since Munki installs from `installer_item_location` and the doubled names worked fine. They're just confusing, and they tempt me into renaming things by hand in the Munki repo, which then doesn't match what the recipe produces next time.

Two that needed something more: Vibeyard's `ARCH` already carries its separator (`-arm64`, empty for Intel), so that one is `%NAME%%ARCH%.dmg` and not `%NAME%-%ARCH%.dmg`. draw.io had a literal `universal` sitting after the version rather than an `%ARCH%`.

